### PR TITLE
Expand parameter policies for `bool` type

### DIFF
--- a/scabha/cargo.py
+++ b/scabha/cargo.py
@@ -99,6 +99,10 @@ class ParameterPolicies(object):
     explicit_true: Optional[str] = None
     # how to pass boolean False values. None = skip option, else pass option name + given value
     explicit_false: Optional[str] = None
+    # pass flag value. None|False = skip, --<flag> true/false | 1/0 | yes/no | t/f
+    explicit_flag: Optional[bool] = None
+    # flag without the '--no-<flag>' option. None|False = skip
+    is_flag: Optional[bool] = None
 
     # if set, a string-type value will be split into a list of arguments using this separator
     split: Optional[str] = None

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -283,7 +283,15 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
             if dtype in _atomic_types:
                 dtype = _atomic_types[dtype]
                 if dtype is bool:
-                    optname = f"{optname}/--no-{name}"
+                    if getattr(policies, "is_flag", None):
+                        kwargs["is_flag"] = True
+                    elif getattr(policies, "explicit_flag"):
+                        # click default behavior for type 'bool'
+                        pass
+                    else:
+                        # leave this as the default behavior for backwards compatibility
+                        # but it really should be the first clause
+                        optname = f"{optname}/--no-{name}"
             # file type? NB: URI not included deliberately -- this becomes a str in the else: clause below
             elif dtype in ("MS", "File", "Directory"):
                 dtype = click.Path(exists=(io is schemas.inputs))

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import os.path
 from typing import List, Optional, Tuple
 

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 import os.path
-import sys
 from typing import List, Optional, Tuple
 
 import click
+from click.testing import CliRunner
+from omegaconf import OmegaConf
 
 from scabha.schema_utils import clickify_parameters
 
@@ -12,7 +13,7 @@ schema_file = os.path.join(os.path.dirname(__file__), "test_clickify.yaml")
 
 @click.command()
 @clickify_parameters(schema_file)
-def func(
+def file_config_app(
     name: str,
     i: int,
     j: Optional[float] = 1,
@@ -32,5 +33,54 @@ def func(
     print(f"output: {output}")
 
 
-if __name__ == "__main__":
-    sys.exit(func())
+def test_file_config():
+    runner = CliRunner()
+    result = runner.invoke(file_config_app, "--j 2 Foo 1".split())
+    assert result.exit_code == 0
+
+
+config = OmegaConf.create(
+    {
+        "inputs": {
+            "flag": dict(info="foo Bar", dtype="bool", policies=dict(is_flag=True)),
+            "explicit-flag": dict(info="foo Bar", dtype="bool", policies=dict(explicit_flag=True)),
+            "yes-no-flag": dict(info="foo Bar", dtype="bool"),
+        },
+        "outputs": {},
+    }
+)
+
+
+@click.command()
+@clickify_parameters(config)
+def boolean_policies_app(**kwargs):
+    assert isinstance(kwargs["flag"], bool)
+
+
+def test_boolean_policies_error_is_flag():
+    runner = CliRunner()
+    result = runner.invoke(boolean_policies_app, "--flag true".split())
+    assert "unexpected extra argument" in result.output
+    assert result.exit_code != 0
+
+    result = runner.invoke(boolean_policies_app, ["--flag"])
+    assert result.exit_code == 0
+
+
+def test_boolean_policies_error_explicit_flag():
+    runner = CliRunner()
+    result = runner.invoke(boolean_policies_app, "--explicit-flag FooBar".split())
+    assert "Invalid value" in result.output
+    assert result.exit_code != 0
+
+    result = runner.invoke(boolean_policies_app, "--explicit-flag false".split())
+    assert result.exit_code == 0
+
+
+def test_boolean_policies_explicit_yes_no():
+    runner = CliRunner()
+    result = runner.invoke(boolean_policies_app, "--yes-no-flag".split())
+    assert result.exit_code == 0
+
+    result = runner.invoke(boolean_policies_app, "--no-yes-no-flag".split())
+    assert result.exit_code == 0

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -81,5 +81,9 @@ def test_boolean_policies_explicit_yes_no():
     result = runner.invoke(boolean_policies_app, "--yes-no-flag".split())
     assert result.exit_code == 0
 
+    result = runner.invoke(boolean_policies_app, "--yes-no-flag true".split())
+    assert "unexpected extra argument" in result.output
+    assert result.exit_code != 0
+
     result = runner.invoke(boolean_policies_app, "--no-yes-no-flag".split())
     assert result.exit_code == 0

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -55,7 +55,3 @@ def test_includes():
     deps.update(deps1)
 
     print(f"Dependencies are: {deps.get_description()}")
-
-
-if __name__ == "__main__":
-    test_includes()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -21,37 +21,6 @@ def test_parser():
         print(f"\n\n\n{a.getName()}")
         print(a.dump())
 
-    # a = expr.parseString("IFSET(a.b)+IFSET(a.b)", parse_all=True)
-    # print(a.dump())
-
-    # a = expr.parseString("a.x==b.x", parse_all=True)
-    # print(a.dump())
-
-    # a = expr.parseString("(a.x==0)==IF(a.x==0,1,2,3)", parse_all=True)
-    # print(a.dump())
-
-    # a = expr.parseString("IFSET(a.b, (a.x==0)==(a.x==0),(a.x!=b.x))", parse_all=True)
-    # print(a.dump())
-
-    # print("===")
-    # a = expr.parseString("a.b OR a.b", parse_all=True)
-    # print(a.dump())
-
-    # a = expr.parse_string("IF((previous.x+1)*previous.x == 2, previous.x == 0, previous.y == 0)", parse_all=True)
-
-    # expr.runTests("""
-    #     (a==0)
-    #     ((a==0)==(a==0))
-    #     IFSET(a.b)
-    #     IFSET(a.b, (a==0)==(a==0),(a!=b))
-    #     IF((previous.x+1)*previous.x == 2, previous.x is 0, previous.y is not 0)
-    #     IF((-previous.x+1)*previous.x == 0, previous.x is 0, previous.y < 0)
-    #     a.b
-    #     """)
-
-
-#    a = expr.parse_string("((a.x))")
-
 
 if __name__ == "__main__":
     test_parser()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -20,7 +20,3 @@ def test_parser():
         a = expr.parseString(string, parse_all=True)
         print(f"\n\n\n{a.getName()}")
         print(a.dump())
-
-
-if __name__ == "__main__":
-    test_parser()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -25,7 +25,3 @@ def test_schema():
 
     obj = OmegaConf.to_object(conf)
     print(obj)
-
-
-if __name__ == "__main__":
-    test_schema()

--- a/tests/test_substitutions.py
+++ b/tests/test_substitutions.py
@@ -186,8 +186,3 @@ def test_formulas():
         assert r["v2"] == 2
         assert r["v3"] == 3
         assert type(r["v4"]) is UNSET
-
-
-if __name__ == "__main__":
-    test_subst()
-    test_formulas()


### PR DESCRIPTION
- add `is_flag` policies for flags without the `--flag/--no-flag` 
- add `explicit_flag` for simpler `--flag true/false` specification
- remove useless shebangs and `__main__` functions