### PR TITLE
Relax Scabha dependency bounds to avoid future dependency issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,24 +12,24 @@ license = "GPL-3.0"
 license-files = ["LICENSE"]
 dependencies = [
     "omegaconf~=2.1",
-    "click>=8.1.3,<9",
-    "pyparsing>=3.0.9,<4",
+    "click>=8.1.3",
+    "pyparsing>=3.0.9",
     "pydantic>=2.7,<3",
-    "psutil>=5.9.3,<6",
-    "rich>=13.7.0,<14",
-    "dill>=0.3.6,<0.4",
-    "typeguard>=4.2.1,<5",
-    "uritools>=5.0.0,<6",
+    "psutil>=5.9.3",
+    "rich>=13.7.0",
+    "dill>=0.3.6",
+    "typeguard>=4.2.1",
+    "uritools>=5.0.0",
 ]
 
 [dependency-groups]
 tests = [
-    "pytest>=7.1.3,<8",
+    "pytest>=7.1.3",
 ]
 docs = [
-    "Sphinx>=5.3.0,<6",
-    "sphinx-copybutton>=0.5.0,<0.6",
-    "furo>=2022.9.15,<2023",
+    "Sphinx>=5.3.0",
+    "sphinx-copybutton>=0.5.0",
+    "furo>=2022.9.15",
 ]
 dev = [
     "pre-commit>=4.3.0",
@@ -46,4 +46,3 @@ include = ["scabha"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-


### PR DESCRIPTION
# Problem

Since Scabha is now an independent library(-like) dependency, the dependencies are harsh when installing into other software projects. Moreover, it would require manual syncing of dependencies across all software repositories which would hinder development processes.

# Goal

Conservatively remove dependency upperbounds to allow upstream software packages, e.g. stimela, to handle dependency bounding. 

# Note

I will leave Pydantic bounds since the major version bumps are code-breaking, e.g. v1 vs v2 vs v3.

https://github.com/caracal-pipeline/scabha/blob/93b61c19ae60bb7231bfa05dcbe1635c3d39f143/pyproject.toml#L17

**Please let me know if there are any dependencies for Scabha that need similar treatment so I can ignore them in my cleaning.