### PR TITLE
Improve error message for wrong type on File inputs

### DIFF
--- a/scabha/validate.py
+++ b/scabha/validate.py
@@ -246,7 +246,9 @@ def validate_parameters(
             elif isinstance(value, (list, tuple)):
                 files = value
             else:
-                raise ParameterValidationError(f"'{mkname(name)}={value}': invalid type '{type(value)}'")
+                raise ParameterValidationError(
+                    f"'{mkname(name)}': expects a file path (string), got {type(value).__name__} '{value}'"
+                )
             # convert to appropriate type
             files = [URI(f) for f in files]
 

--- a/scabha/validate.py
+++ b/scabha/validate.py
@@ -246,11 +246,20 @@ def validate_parameters(
             elif isinstance(value, (list, tuple)):
                 files = value
             else:
+                if schema.is_file_list_type:
+                    raise ParameterValidationError(
+                        f"'{mkname(name)}': expects a list of file paths, got {type(value).__name__} '{value}'"
+                    )
                 raise ParameterValidationError(
                     f"'{mkname(name)}': expects a file path (string), got {type(value).__name__} '{value}'"
                 )
             # convert to appropriate type
-            files = [URI(f) for f in files]
+            try:
+                files = [URI(f) for f in files]
+            except TypeError as exc:
+                raise ParameterValidationError(
+                    f"'{mkname(name)}': invalid element in file list, all elements must be strings: {exc}"
+                )
 
             # check for existence of all files in list, if needed
             if must_exist:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -294,6 +294,16 @@ class TestErrorFlow:
             run_validate({"my_param": "not-an-int"}, {"my_param": make_schema("int")})
         assert "my_param" in str(exc_info.value)
 
+    def test_file_input_wrong_type_error_message(self):
+        """Passing a non-string type (e.g. int) for a File param gives a clear error (GH stimela#408)."""
+        with pytest.raises(ParameterValidationError, match=r"expects a file path \(string\)"):
+            run_validate({"my_file": 42}, {"my_file": make_schema("File")})
+
+    def test_file_input_wrong_type_mentions_actual_type(self):
+        """The error message for a wrong-typed File input mentions the actual type name."""
+        with pytest.raises(ParameterValidationError, match=r"\bint\b"):
+            run_validate({"my_file": 42}, {"my_file": make_schema("File")})
+
 
 # --- choices ----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Fixes https://github.com/caracal-pipeline/stimela/issues/408
- When a non-string value (e.g. an int) is passed for a File-typed parameter, the error message now says `'param_name': expects a file path (string), got int '5'` instead of the confusing `'param_name=5': invalid type '<class 'int'>'`
- Uses `type(value).__name__` for a clean type name display

## Test plan

- [ ] Pass an integer value for a File-typed input parameter and verify the error message is clear
- [ ] Pass a float value for a File-typed input parameter and verify the error message is clear
- [ ] Pass a valid string path and verify normal behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)