### PR TITLE
Fix positional metavar and Optional[str] defaults in clickify

### DIFF
--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -268,6 +268,7 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
             nargs = 1
             # process optional
             optional_match = re.fullmatch(r"Optional\[(.*)\]", dtype)
+            is_optional = optional_match is not None
             if optional_match:
                 str_dtype = dtype = optional_match.group(1).strip()
             else:
@@ -277,6 +278,11 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
             kwargs = dict()
             if not is_unset and not schema.suppress_cli_default and nargs != -1:
                 kwargs["default"] = schema.default
+            # for Optional types with unset defaults, explicitly pass None as default
+            # to ensure Click passes None to the function rather than relying on
+            # implicit behavior (fixes stimela#415)
+            elif is_optional and is_unset and not schema.suppress_cli_default:
+                kwargs["default"] = None
 
             # sort out option type. Atomic type?
             if dtype in _atomic_types:
@@ -369,7 +375,10 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                 optnames.append(f"-{schema.abbreviation}")
 
             if policies.positional:
-                kwargs.update(type=dtype, callback=validator, required=schema.required, nargs=nargs, metavar=metavar)
+                # for positional arguments, default metavar to the parameter name
+                # rather than dtype, which is more informative (fixes stimela#424)
+                pos_metavar = schema.metavar or name.upper()
+                kwargs.update(type=dtype, callback=validator, required=schema.required, nargs=nargs, metavar=pos_metavar)
                 deco = click.argument(name, **kwargs)
             else:
                 kwargs.update(

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -90,6 +90,150 @@ def test_boolean_policies_explicit_yes_no():
     assert result.exit_code == 0
 
 
+# -- Tests for positional metavar (stimela#424) --
+
+positional_config = OmegaConf.create(
+    {
+        "inputs": {
+            "input_file": dict(dtype="str", required=True, info="Input file", policies=dict(positional=True)),
+            "output_dir": dict(dtype="str", required=True, info="Output directory", policies=dict(positional=True)),
+            "count": dict(dtype="int", info="Number of items"),
+        },
+        "outputs": {},
+    }
+)
+
+
+@click.command("positional-app")
+@clickify_parameters(positional_config)
+def positional_app(**kwargs):
+    for k, v in sorted(kwargs.items()):
+        click.echo(f"{k}={v!r}")
+
+
+def test_positional_metavar_uses_name():
+    """Positional arguments should show their name (uppercased) as metavar, not dtype."""
+    runner = CliRunner()
+    result = runner.invoke(positional_app, ["--help"])
+    assert result.exit_code == 0
+    # Usage line should show parameter names, not dtype strings like 'str'
+    assert "INPUT-FILE" in result.output
+    assert "OUTPUT-DIR" in result.output
+
+
+def test_positional_metavar_does_not_show_dtype():
+    """Positional metavar should not be the dtype string."""
+    runner = CliRunner()
+    result = runner.invoke(positional_app, ["--help"])
+    assert result.exit_code == 0
+    # The usage line should not contain bare 'str' as positional metavar.
+    # Options like --count may show 'int' in their help, but the usage line
+    # for positionals (before Options:) should use names.
+    usage_line = result.output.split("\n")[0]
+    # The usage line should not have 'str' as a standalone positional metavar
+    assert "INPUT-FILE" in usage_line
+    assert "OUTPUT-DIR" in usage_line
+
+
+positional_custom_metavar_config = OmegaConf.create(
+    {
+        "inputs": {
+            "input_file": dict(
+                dtype="str", required=True, info="Input", policies=dict(positional=True), metavar="MYFILE"
+            ),
+        },
+        "outputs": {},
+    }
+)
+
+
+@click.command("positional-custom-metavar-app")
+@clickify_parameters(positional_custom_metavar_config)
+def positional_custom_metavar_app(**kwargs):
+    pass
+
+
+def test_positional_explicit_metavar_respected():
+    """When schema.metavar is explicitly set, it should override the name-based default."""
+    runner = CliRunner()
+    result = runner.invoke(positional_custom_metavar_app, ["--help"])
+    assert result.exit_code == 0
+    assert "MYFILE" in result.output
+
+
+def test_positional_app_runs():
+    """Positional arguments should still work correctly."""
+    runner = CliRunner()
+    result = runner.invoke(positional_app, ["foo.txt", "/tmp/out"])
+    assert result.exit_code == 0
+    assert "input_file='foo.txt'" in result.output
+    assert "output_dir='/tmp/out'" in result.output
+
+
+# -- Tests for Optional[str] defaults (stimela#415) --
+
+optional_str_config = OmegaConf.create(
+    {
+        "inputs": {
+            "with_default": dict(dtype="Optional[str]", default="hello.fits", info="Has a default"),
+            "no_default": dict(dtype="Optional[str]", info="No default set"),
+            "null_default": dict(dtype="Optional[str]", default=None, info="Explicit null default"),
+            "regular_str": dict(dtype="str", info="Non-optional string"),
+        },
+        "outputs": {},
+    }
+)
+
+
+@click.command("optional-str-app")
+@clickify_parameters(optional_str_config)
+def optional_str_app(**kwargs):
+    for k, v in sorted(kwargs.items()):
+        click.echo(f"{k}={v!r}")
+
+
+def test_optional_str_with_default():
+    """Optional[str] with an explicit default should pass the default through."""
+    runner = CliRunner()
+    result = runner.invoke(optional_str_app, [])
+    assert result.exit_code == 0
+    assert "with_default='hello.fits'" in result.output
+
+
+def test_optional_str_no_default_is_none():
+    """Optional[str] with no default (UNSET) should get None, not be missing."""
+    runner = CliRunner()
+    result = runner.invoke(optional_str_app, [])
+    assert result.exit_code == 0
+    assert "no_default=None" in result.output
+
+
+def test_optional_str_null_default_is_none():
+    """Optional[str] with explicit null default should get None."""
+    runner = CliRunner()
+    result = runner.invoke(optional_str_app, [])
+    assert result.exit_code == 0
+    assert "null_default=None" in result.output
+
+
+def test_optional_str_provided_value():
+    """Optional[str] parameters should accept provided values."""
+    runner = CliRunner()
+    result = runner.invoke(optional_str_app, ["--no-default", "provided.fits"])
+    assert result.exit_code == 0
+    assert "no_default='provided.fits'" in result.output
+
+
+def test_optional_str_override_default():
+    """Optional[str] with a default can be overridden by CLI arg."""
+    runner = CliRunner()
+    result = runner.invoke(optional_str_app, ["--with-default", "override.fits"])
+    assert result.exit_code == 0
+    assert "with_default='override.fits'" in result.output
+
+
+# -- Existing lazy group tests --
+
 @click.group(cls=LazyGroup, lazy_subcommands={"hello-world": "tests.hello_app.hello_world"})
 def cli_group():
     pass

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -116,9 +116,13 @@ def test_positional_metavar_uses_name():
     runner = CliRunner()
     result = runner.invoke(positional_app, ["--help"])
     assert result.exit_code == 0
+    usage_line = result.output.split("\n")[0]
     # Usage line should show parameter names, not dtype strings like 'str'
-    assert "INPUT-FILE" in result.output
-    assert "OUTPUT-DIR" in result.output
+    assert "INPUT-FILE" in usage_line
+    assert "OUTPUT-DIR" in usage_line
+    # dtype should not appear as a standalone metavar in the usage line
+    usage_tokens = usage_line.split()
+    assert "str" not in usage_tokens, f"dtype 'str' should not appear as metavar in usage line: {usage_line}"
 
 
 def test_positional_metavar_does_not_show_dtype():
@@ -126,13 +130,11 @@ def test_positional_metavar_does_not_show_dtype():
     runner = CliRunner()
     result = runner.invoke(positional_app, ["--help"])
     assert result.exit_code == 0
-    # The usage line should not contain bare 'str' as positional metavar.
-    # Options like --count may show 'int' in their help, but the usage line
-    # for positionals (before Options:) should use names.
     usage_line = result.output.split("\n")[0]
-    # The usage line should not have 'str' as a standalone positional metavar
     assert "INPUT-FILE" in usage_line
     assert "OUTPUT-DIR" in usage_line
+    usage_tokens = usage_line.split()
+    assert "str" not in usage_tokens, f"dtype 'str' should not appear as metavar in usage line: {usage_line}"
 
 
 positional_custom_metavar_config = OmegaConf.create(
@@ -233,6 +235,7 @@ def test_optional_str_override_default():
 
 
 # -- Existing lazy group tests --
+
 
 @click.group(cls=LazyGroup, lazy_subcommands={"hello-world": "tests.hello_app.hello_world"})
 def cli_group():


### PR DESCRIPTION
## Summary

- **Positional metavar** (fixes caracal-pipeline/stimela#424): Set the default metavar of positional Click arguments to the parameter name (uppercased) instead of the dtype string. This makes CLI help text like `Usage: cmd [OPTIONS] INPUT-FILE OUTPUT-DIR` instead of `Usage: cmd [OPTIONS] str str`. The explicit `schema.metavar` field is still respected when set by the user.

- **Optional[str] defaults** (fixes caracal-pipeline/stimela#415): For `Optional[...]` types with unset defaults, explicitly pass `default=None` to Click rather than relying on Click's implicit `None` fallback. This ensures consistent behavior for Optional parameters across all Click configurations and callback/validator scenarios.

## Test plan

- [x] Verified positional metavar shows parameter name in help text
- [x] Verified `schema.metavar` override still works for positionals
- [x] Verified `Optional[str]` with string default passes through correctly
- [x] Verified `Optional[str]` with no default gets explicit `None`
- [x] Verified `Optional[str]` with `null` default gets `None`
- [x] All 59 stimela tests pass (one pre-existing failure in `test_test_recipe` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)