### PR TITLE
Fix {}-substitutions failing on container types

### DIFF
--- a/scabha/validate.py
+++ b/scabha/validate.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E731 - ignore assignment of lambda expressions. TODO(JSKenyon): Fix this.
+import ast
 import dataclasses
 import keyword
 import logging
@@ -7,7 +8,7 @@ import os.path
 import pathlib
 import re
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, get_origin
 
 import pydantic
 import pydantic.dataclasses
@@ -209,6 +210,21 @@ def validate_parameters(
                 inputs[name] = OmegaConf.to_container(value)
             elif isinstance(value, bool) and schema._dtype is str:
                 inputs[name] = str(value)
+            elif isinstance(value, str) and get_origin(schema._dtype) in (list, tuple, dict):
+                # When a {}-substitution converts a container value to a string
+                # (e.g. "[(30.0, 120.0), (90.0, 360.0)]"), try to parse it back
+                # into a Python object so pydantic can validate the structure.
+                # ast.literal_eval handles Python literal syntax including tuples;
+                # yaml.safe_load is tried as a fallback for simpler list/dict
+                # notations.
+                for parser in (ast.literal_eval, yaml.safe_load):
+                    try:
+                        parsed = parser(value)
+                    except Exception:
+                        continue
+                    if isinstance(parsed, (list, tuple, dict)):
+                        inputs[name] = parsed
+                        break
 
     dcls = dataclasses.make_dataclass("Parameters", fields)
 

--- a/scabha/validate.py
+++ b/scabha/validate.py
@@ -8,7 +8,7 @@ import os.path
 import pathlib
 import re
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, get_origin
+from typing import Any, Callable, Dict, List, Optional, Union, get_args, get_origin
 
 import pydantic
 import pydantic.dataclasses
@@ -75,6 +75,23 @@ def evaluate_and_substitute(
             if errors:
                 raise SubstitutionErrorList("unresolved {}-substitutions", errors)
     return inputs
+
+
+_CONTAINER_TYPES = (list, tuple, dict)
+
+
+def _is_container_dtype(dtype) -> bool:
+    """Check if a dtype is a container type (list/tuple/dict), unwrapping Optional/Union."""
+    if dtype in _CONTAINER_TYPES:
+        return True
+    origin = get_origin(dtype)
+    if origin in _CONTAINER_TYPES:
+        return True
+    # Unwrap Optional[X] / Union[X, None] and check the inner type
+    if origin is Union:
+        args = [a for a in get_args(dtype) if a is not type(None)]
+        return any(_is_container_dtype(a) for a in args)
+    return False
 
 
 def validate_parameters(
@@ -210,7 +227,7 @@ def validate_parameters(
                 inputs[name] = OmegaConf.to_container(value)
             elif isinstance(value, bool) and schema._dtype is str:
                 inputs[name] = str(value)
-            elif isinstance(value, str) and get_origin(schema._dtype) in (list, tuple, dict):
+            elif isinstance(value, str) and _is_container_dtype(schema._dtype):
                 # When a {}-substitution converts a container value to a string
                 # (e.g. "[(30.0, 120.0), (90.0, 360.0)]"), try to parse it back
                 # into a Python object so pydantic can validate the structure.

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -194,6 +194,92 @@ class TestNestedDtypes:
             run_validate({"b": [[1, 2, 3, 4]]}, {"b": make_schema(self.NESTED)})
 
 
+class TestStringToContainerCoercion:
+    """Tests for parsing string representations of containers back into Python
+    objects. This is the fix for stimela issue #364: {}-substitutions convert
+    container values to strings, which then fail pydantic validation for
+    complex types like List[Tuple[float,float]].
+    """
+
+    def test_list_tuple_float_from_string(self):
+        """Core case from issue #364: List[Tuple[float,float]] passed as string."""
+        out = run_validate(
+            {"kernel": "[(30.0, 120.0), (90.0, 360.0)]"},
+            {"kernel": make_schema("List[Tuple[float,float]]")},
+        )
+        assert out["kernel"] == [(30.0, 120.0), (90.0, 360.0)]
+
+    def test_list_int_from_string(self):
+        """List[int] passed as string via {}-substitution."""
+        out = run_validate(
+            {"bounds": "[0, -1]"},
+            {"bounds": make_schema("List[int]")},
+        )
+        assert out["bounds"] == [0, -1]
+
+    def test_list_float_from_string(self):
+        out = run_validate(
+            {"x": "[1.5, 2.5, 3.5]"},
+            {"x": make_schema("List[float]")},
+        )
+        assert out["x"] == [1.5, 2.5, 3.5]
+
+    def test_list_str_from_string_unchanged(self):
+        """A plain string for List[str] should not be parsed as a container --
+        pydantic should handle it normally (likely raising an error since a bare
+        string is not a list)."""
+        with pytest.raises(ParameterValidationError):
+            run_validate(
+                {"x": "hello"},
+                {"x": make_schema("List[str]")},
+            )
+
+    def test_dict_from_string(self):
+        out = run_validate(
+            {"x": "{'a': 1, 'b': 2}"},
+            {"x": make_schema("Dict[str, int]")},
+        )
+        assert out["x"] == {"a": 1, "b": 2}
+
+    def test_tuple_from_string(self):
+        out = run_validate(
+            {"x": "(1, 2.5)"},
+            {"x": make_schema("Tuple[int, float]")},
+        )
+        assert list(out["x"]) == [1, 2.5]
+
+    def test_nested_list_of_lists_from_string(self):
+        out = run_validate(
+            {"x": "[[1, 2], [3, 4]]"},
+            {"x": make_schema("List[List[int]]")},
+        )
+        assert out["x"] == [[1, 2], [3, 4]]
+
+    def test_malformed_string_still_raises(self):
+        """Strings that can't be parsed should still fail validation."""
+        with pytest.raises(ParameterValidationError):
+            run_validate(
+                {"x": "not a list at all"},
+                {"x": make_schema("List[int]")},
+            )
+
+    def test_string_for_scalar_dtype_unaffected(self):
+        """String values for scalar dtypes should not trigger container parsing."""
+        out = run_validate(
+            {"x": "42"},
+            {"x": make_schema("int")},
+        )
+        assert out["x"] == 42
+
+    def test_yaml_fallback_for_simple_list(self):
+        """YAML notation like [1, 2, 3] should also work via yaml.safe_load."""
+        out = run_validate(
+            {"x": "[1, 2, 3]"},
+            {"x": make_schema("List[int]")},
+        )
+        assert out["x"] == [1, 2, 3]
+
+
 # --- File / Directory / URI -------------------------------------------------
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -272,10 +272,18 @@ class TestStringToContainerCoercion:
         assert out["x"] == 42
 
     def test_yaml_fallback_for_simple_list(self):
-        """YAML notation like [1, 2, 3] should also work via yaml.safe_load."""
+        """YAML block-list notation should be parsed via the yaml.safe_load fallback."""
+        out = run_validate(
+            {"x": "- 1\n- 2\n- 3"},
+            {"x": make_schema("List[int]")},
+        )
+        assert out["x"] == [1, 2, 3]
+
+    def test_optional_container_from_string(self):
+        """Optional[List[...]] should still trigger container-string parsing."""
         out = run_validate(
             {"x": "[1, 2, 3]"},
-            {"x": make_schema("List[int]")},
+            {"x": make_schema("Optional[List[int]]")},
         )
         assert out["x"] == [1, 2, 3]
 


### PR DESCRIPTION
## Summary
- When a `{}`-substitution converts a container value to its string representation (e.g. `[(30.0, 120.0), (90.0, 360.0)]`), pydantic cannot parse it back into the expected type like `List[Tuple[float,float]]`
- Adds a pre-validation step in `validate_parameters` that detects string values for container dtypes (`list`, `tuple`, `dict`) and parses them via `ast.literal_eval` (with `yaml.safe_load` as fallback) before passing to pydantic
- Adds 10 tests covering the core issue case, various container types, edge cases, and error handling

Fixes caracal-pipeline/stimela#364

## Test plan
- [x] All 77 existing + new tests pass
- [x] Core case `List[Tuple[float,float]]` from string validated correctly
- [x] `List[int]`, `List[float]`, `Dict[str,int]`, `Tuple[int,float]` all work from string
- [x] Malformed strings still raise `ParameterValidationError`
- [x] Scalar dtypes are unaffected
- [x] Ruff lint and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)