### PR TITLE
fixes #12: support arbitrary placement of _include and _use

### DIFF
--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -245,29 +245,29 @@ def resolve_config_refs(
 
     if isinstance(conf, DictConfig):
         # validate placement of standard directives before the processing loop
-        _is_directive = lambda k: (  # noqa: E731
+        is_directive = lambda k: (  # noqa: E731
             k in ("_include", "_use", "_include_post", "_use_post", "_scrub", "_scrub_post")
             or k.startswith("_include_")
             or k.startswith("_use_")
             or k.startswith("_scrub_")
         )
-        _conf_keys = list(conf.keys())
-        _first_non_dir = next((i for i, k in enumerate(_conf_keys) if not _is_directive(k)), None)
-        _last_non_post = None
-        for _i, _k in enumerate(_conf_keys):
-            if _k not in ("_include_post", "_use_post", "_scrub_post"):
-                _last_non_post = _i
-        for _i, _key in enumerate(_conf_keys):
-            if _key in ("_include", "_use"):
-                if _first_non_dir is not None and _i > _first_non_dir:
+        conf_keys = list(conf.keys())
+        first_non_dir = next((i for i, k in enumerate(conf_keys) if not is_directive(k)), None)
+        last_non_post = None
+        for i, k in enumerate(conf_keys):
+            if k not in ("_include_post", "_use_post", "_scrub_post"):
+                last_non_post = i
+        for i, key in enumerate(conf_keys):
+            if key in ("_include", "_use"):
+                if first_non_dir is not None and i > first_non_dir:
                     raise ConfigurattError(
-                        f"{errloc}: '{_key}' must appear at the top of the mapping before any content keys; "
-                        f"use '_{_key.lstrip('_')}_<suffix>' for mid-mapping placement"
+                        f"{errloc}: '{key}' must appear at the top of the mapping before any content keys; "
+                        f"use '_{key.lstrip('_')}_<suffix>' for mid-mapping placement"
                     )
-            elif _key in ("_include_post", "_use_post"):
-                if _last_non_post is not None and _i < _last_non_post:
+            elif key in ("_include_post", "_use_post"):
+                if last_non_post is not None and i < last_non_post:
                     raise ConfigurattError(
-                        f"{errloc}: '{_key}' must appear at the bottom of the mapping after all content keys"
+                        f"{errloc}: '{key}' must appear at the bottom of the mapping after all content keys"
                     )
 
         # since _use and _include statements can be nested, keep on processing until all are resolved

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -519,15 +519,16 @@ def resolve_config_refs(
             # preserved so that nested keys are handled correctly.
             if loaded_directives:
                 updated = True
-                new_conf = OmegaConf.create()
+                # Collect parts in key order, then merge once — O(N) instead of O(N²).
+                parts = []
                 for key in orig_keys:
                     if key in loaded_directives:
                         loaded = loaded_directives[key]
                         if loaded is not None:
-                            new_conf = OmegaConf.unsafe_merge(new_conf, loaded)
+                            parts.append(loaded)
                     elif key in conf:
-                        new_conf = OmegaConf.unsafe_merge(new_conf, OmegaConf.masked_copy(conf, [key]))
-                conf = new_conf
+                        parts.append(OmegaConf.masked_copy(conf, [key]))
+                conf = OmegaConf.unsafe_merge(*parts) if parts else OmegaConf.create()
                 if selfrefs:
                     use_sources[0] = conf
 

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -245,12 +245,14 @@ def resolve_config_refs(
 
     if isinstance(conf, DictConfig):
         # validate placement of standard directives before the processing loop
-        is_directive = lambda k: (  # noqa: E731
-            k in ("_include", "_use", "_scrub")
-            or k.startswith("_include_")
-            or k.startswith("_use_")
-            or k.startswith("_scrub_")
-        )
+        def is_directive(k):
+            return (
+                k in ("_include", "_use", "_scrub")
+                or k.startswith("_include_")
+                or k.startswith("_use_")
+                or k.startswith("_scrub_")
+            )
+
         conf_keys = list(conf.keys())
         first_non_dir = next((i for i, k in enumerate(conf_keys) if not is_directive(k)), None)
         last_non_post = None

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -513,8 +513,11 @@ def resolve_config_refs(
                     use_sources[0] = conf
 
             # handle arbitrary-suffix _include_xxx and _use_xxx directives (in-place insertion)
-            arb_include = {k for k in conf.keys() if k.startswith("_include_") and k != "_include_post"}
-            arb_use = {k for k in conf.keys() if k.startswith("_use_") and k != "_use_post"}
+            # Filter at collection time: only include keys that can actually be processed now.
+            # If includes=False or use_sources is None, the corresponding directives are left
+            # untouched rather than triggering a spurious update cycle (which would loop forever).
+            arb_include = {k for k in conf.keys() if includes and k.startswith("_include_") and k != "_include_post"}
+            arb_use = {k for k in conf.keys() if use_sources is not None and k.startswith("_use_") and k != "_use_post"}
             if arb_include or arb_use:
                 updated = True
                 # snapshot key order before any pops, then load each directive's content

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -246,7 +246,7 @@ def resolve_config_refs(
     if isinstance(conf, DictConfig):
         # validate placement of standard directives before the processing loop
         is_directive = lambda k: (  # noqa: E731
-            k in ("_include", "_use", "_include_post", "_use_post", "_scrub", "_scrub_post")
+            k in ("_include", "_use", "_scrub")
             or k.startswith("_include_")
             or k.startswith("_use_")
             or k.startswith("_scrub_")
@@ -280,7 +280,13 @@ def resolve_config_refs(
             recurse += 1
             if recurse > 20:
                 raise ConfigurattError(f"{errloc}: recursion limit exceeded, check your _use and _include statements")
-            # handle _include/_include_post entries
+
+            # All _include/_use directives (bare, suffixed, and _post) use the same positional-insertion
+            # semantics: directives appearing later in the mapping have higher priority than earlier ones.
+            # Snapshot key order up front; helper functions pop their directive keys from conf as they run.
+            orig_keys = list(conf.keys())
+            loaded_directives = {}
+
             if includes:
                 # helper function: process includes recursively
                 def process_include_directive(include_files: List[str], keyword: str, directive: Any, subpath=None):
@@ -297,19 +303,14 @@ def resolve_config_refs(
                     else:
                         raise ConfigurattError(f"{errloc}: {keyword} contains invalid entry of type {type(directive)}")
 
-                # helper function: load list of _include or _include_post files, returns accumulated DictConfig
+                # helper function: load list of include files, returns accumulated DictConfig
                 def load_include_files(keyword):
                     # pop include directive, return if None
                     include_directive = pop_conf(conf, keyword, None)
                     if include_directive is None:
                         return None
-                    # get corresponding _scrub or _scrub_post directive
-                    if keyword == "_include":
-                        scrub_key = "_scrub"
-                    elif keyword == "_include_post":
-                        scrub_key = "_scrub_post"
-                    else:
-                        scrub_key = "_scrub_" + keyword[len("_include_") :]
+                    # get corresponding _scrub directive (_include → _scrub, _include_X → _scrub_X)
+                    scrub_key = "_scrub" if keyword == "_include" else "_scrub_" + keyword[len("_include_") :]
                     scrub = pop_conf(conf, scrub_key, None)
                     if isinstance(scrub, str):
                         scrub = [scrub]
@@ -464,29 +465,18 @@ def resolve_config_refs(
 
                     return accum_incl_conf
 
-                accum_pre = load_include_files("_include")
-                accum_post = load_include_files("_include_post")
+                for key in orig_keys:
+                    if key == "_include" or key.startswith("_include_"):
+                        loaded_directives[key] = load_include_files(key)
 
-                # merge: our section overrides anything that has been included
-                conf = OmegaConf.unsafe_merge(accum_pre or {}, conf, accum_post or {})
-                if accum_pre or accum_post:
-                    updated = True
-                if selfrefs:
-                    use_sources[0] = conf
-
-            # handle _use entries
             if use_sources is not None:
 
                 def load_use_sections(keyword):
                     merge_sections = pop_conf(conf, keyword, None)
                     if merge_sections is None:
                         return None
-                    if keyword == "_use":
-                        scrub_key = "_scrub"
-                    elif keyword == "_use_post":
-                        scrub_key = "_scrub_post"
-                    else:
-                        scrub_key = "_scrub_" + keyword[len("_use_") :]
+                    # get corresponding _scrub directive (_use → _scrub, _use_X → _scrub_X)
+                    scrub_key = "_scrub" if keyword == "_use" else "_scrub_" + keyword[len("_use_") :]
                     scrub = pop_conf(conf, scrub_key, None)
                     if type(merge_sections) is str:
                         merge_sections = [merge_sections]
@@ -518,43 +508,25 @@ def resolve_config_refs(
                         return base
                     return None
 
-                base = load_use_sections("_use")
-                if base is not None:
-                    base.merge_with(conf)
-                    conf = base
-                post = load_use_sections("_use_post")
-                if post is not None:
-                    conf.merge_with(post)
-
-                if selfrefs:
-                    use_sources[0] = conf
-
-            # handle arbitrary-suffix _include_xxx and _use_xxx directives (in-place insertion)
-            # Filter at collection time: only include keys that can actually be processed now.
-            # If includes=False or use_sources is None, the corresponding directives are left
-            # untouched rather than triggering a spurious update cycle (which would loop forever).
-            arb_include = {k for k in conf.keys() if includes and k.startswith("_include_") and k != "_include_post"}
-            arb_use = {k for k in conf.keys() if use_sources is not None and k.startswith("_use_") and k != "_use_post"}
-            if arb_include or arb_use:
-                updated = True
-                # snapshot key order before any pops, then load each directive's content
-                orig_keys = list(conf.keys())
-                loaded_directives = {}
                 for key in orig_keys:
-                    if key in arb_include and includes:
-                        loaded_directives[key] = load_include_files(key)
-                    elif key in arb_use and use_sources is not None:
+                    if (key == "_use" or key.startswith("_use_")) and key not in loaded_directives:
                         loaded_directives[key] = load_use_sections(key)
-                # rebuild conf with directive content inserted at the right positions
+
+            # Rebuild conf: merge each directive's content at its position in the key order.
+            # Merges are applied in mapping order, so later entries override earlier ones —
+            # uniform positional semantics for all directive forms (_include, _include_SUFFIX,
+            # _include_post, _use, _use_SUFFIX, _use_post). Full (deep) merge semantics are
+            # preserved so that nested keys are handled correctly.
+            if loaded_directives:
+                updated = True
                 new_conf = OmegaConf.create()
                 for key in orig_keys:
                     if key in loaded_directives:
                         loaded = loaded_directives[key]
                         if loaded is not None:
-                            for k in loaded:
-                                new_conf[k] = loaded[k]
+                            new_conf = OmegaConf.unsafe_merge(new_conf, loaded)
                     elif key in conf:
-                        new_conf[key] = conf[key]
+                        new_conf = OmegaConf.unsafe_merge(new_conf, OmegaConf.masked_copy(conf, [key]))
                 conf = new_conf
                 if selfrefs:
                     use_sources[0] = conf

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -253,13 +253,9 @@ def resolve_config_refs(
         )
         _conf_keys = list(conf.keys())
         _first_non_dir = next((i for i, k in enumerate(_conf_keys) if not _is_directive(k)), None)
-        _last_non_dir = None
-        for _i, _k in enumerate(_conf_keys):
-            if not _is_directive(_k):
-                _last_non_dir = _i
         _last_non_post = None
         for _i, _k in enumerate(_conf_keys):
-            if _k not in ("_include_post", "_use_post"):
+            if _k not in ("_include_post", "_use_post", "_scrub_post"):
                 _last_non_post = _i
         for _i, _key in enumerate(_conf_keys):
             if _key in ("_include", "_use"):

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -257,6 +257,10 @@ def resolve_config_refs(
         for _i, _k in enumerate(_conf_keys):
             if not _is_directive(_k):
                 _last_non_dir = _i
+        _last_non_post = None
+        for _i, _k in enumerate(_conf_keys):
+            if _k not in ("_include_post", "_use_post"):
+                _last_non_post = _i
         for _i, _key in enumerate(_conf_keys):
             if _key in ("_include", "_use"):
                 if _first_non_dir is not None and _i > _first_non_dir:
@@ -265,7 +269,7 @@ def resolve_config_refs(
                         f"use '_{_key.lstrip('_')}_<suffix>' for mid-mapping placement"
                     )
             elif _key in ("_include_post", "_use_post"):
-                if _last_non_dir is not None and _i < _last_non_dir:
+                if _last_non_post is not None and _i < _last_non_post:
                     raise ConfigurattError(
                         f"{errloc}: '{_key}' must appear at the bottom of the mapping after all content keys"
                     )
@@ -551,9 +555,10 @@ def resolve_config_refs(
                     if key in loaded_directives:
                         loaded = loaded_directives[key]
                         if loaded is not None:
-                            new_conf = OmegaConf.unsafe_merge(new_conf, loaded)
+                            for k in loaded:
+                                new_conf[k] = loaded[k]
                     elif key in conf:
-                        new_conf = OmegaConf.unsafe_merge(new_conf, OmegaConf.create({key: conf[key]}))
+                        new_conf[key] = conf[key]
                 conf = new_conf
                 if selfrefs:
                     use_sources[0] = conf

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -534,6 +534,20 @@ def resolve_config_refs(
                 if selfrefs:
                     use_sources[0] = conf
 
+        # Detect orphaned _scrub / _scrub_<suffix> keys: their companion directive was
+        # never present (or was misspelled), so they were never popped during processing.
+        # Exception: if the companion directive is still in conf, processing was simply
+        # disabled (includes=False or use_sources=None) — not an error in that case.
+        for key in conf.keys():
+            if key == "_scrub" or key.startswith("_scrub_"):
+                if key == "_scrub":
+                    has_companion = "_include" in conf or "_use" in conf
+                else:
+                    suffix = key[len("_scrub_") :]
+                    has_companion = f"_include_{suffix}" in conf or f"_use_{suffix}" in conf
+                if not has_companion:
+                    raise ConfigurattError(f"{errloc}: '{key}' has no matching _include or _use directive")
+
         # recurse into content
         for key, value in conf.items_ex(resolve=False):
             if isinstance(value, (DictConfig, ListConfig)):

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -244,8 +244,27 @@ def resolve_config_refs(
     selfrefs = use_sources and conf is use_sources[0]
 
     if isinstance(conf, DictConfig):
-        ## NB: perhaps have _use and _include take effect at the point they're inserted?
-        ## also add an _all statement to insert a section into all section that follow
+        # validate placement of standard directives before the processing loop
+        _is_directive = lambda k: k.startswith("_include") or k.startswith("_use") or k.startswith("_scrub")  # noqa: E731
+        _conf_keys = list(conf.keys())
+        _first_non_dir = next((i for i, k in enumerate(_conf_keys) if not _is_directive(k)), None)
+        _last_non_dir = None
+        for _i, _k in enumerate(_conf_keys):
+            if not _is_directive(_k):
+                _last_non_dir = _i
+        for _i, _key in enumerate(_conf_keys):
+            if _key in ("_include", "_use"):
+                if _first_non_dir is not None and _i > _first_non_dir:
+                    raise ConfigurattError(
+                        f"{errloc}: '{_key}' must appear at the top of the mapping before any content keys; "
+                        f"use '_{_key.lstrip('_')}_SUFFIX' for mid-mapping placement"
+                    )
+            elif _key in ("_include_post", "_use_post"):
+                if _last_non_dir is not None and _i < _last_non_dir:
+                    raise ConfigurattError(
+                        f"{errloc}: '{_key}' must appear at the bottom of the mapping after all content keys"
+                    )
+
         # since _use and _include statements can be nested, keep on processing until all are resolved
         updated = True
         recurse = 0
@@ -490,6 +509,32 @@ def resolve_config_refs(
                 if post is not None:
                     conf.merge_with(post)
 
+                if selfrefs:
+                    use_sources[0] = conf
+
+            # handle arbitrary-suffix _include_xxx and _use_xxx directives (in-place insertion)
+            arb_include = {k for k in conf.keys() if k.startswith("_include_") and k != "_include_post"}
+            arb_use = {k for k in conf.keys() if k.startswith("_use_") and k != "_use_post"}
+            if arb_include or arb_use:
+                updated = True
+                # snapshot key order before any pops, then load each directive's content
+                orig_keys = list(conf.keys())
+                loaded_directives = {}
+                for key in orig_keys:
+                    if key in arb_include and includes:
+                        loaded_directives[key] = load_include_files(key)
+                    elif key in arb_use and use_sources is not None:
+                        loaded_directives[key] = load_use_sections(key)
+                # rebuild conf with directive content inserted at the right positions
+                new_conf = OmegaConf.create()
+                for key in orig_keys:
+                    if key in loaded_directives:
+                        loaded = loaded_directives[key]
+                        if loaded is not None:
+                            new_conf = OmegaConf.unsafe_merge(new_conf, loaded)
+                    elif key in conf:
+                        new_conf = OmegaConf.unsafe_merge(new_conf, OmegaConf.create({key: conf[key]}))
+                conf = new_conf
                 if selfrefs:
                     use_sources[0] = conf
 

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -245,7 +245,12 @@ def resolve_config_refs(
 
     if isinstance(conf, DictConfig):
         # validate placement of standard directives before the processing loop
-        _is_directive = lambda k: k.startswith("_include") or k.startswith("_use") or k.startswith("_scrub")  # noqa: E731
+        _is_directive = lambda k: (  # noqa: E731
+            k in ("_include", "_use", "_include_post", "_use_post", "_scrub", "_scrub_post")
+            or k.startswith("_include_")
+            or k.startswith("_use_")
+            or k.startswith("_scrub_")
+        )
         _conf_keys = list(conf.keys())
         _first_non_dir = next((i for i, k in enumerate(_conf_keys) if not _is_directive(k)), None)
         _last_non_dir = None

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -262,7 +262,7 @@ def resolve_config_refs(
                 if _first_non_dir is not None and _i > _first_non_dir:
                     raise ConfigurattError(
                         f"{errloc}: '{_key}' must appear at the top of the mapping before any content keys; "
-                        f"use '_{_key.lstrip('_')}_SUFFIX' for mid-mapping placement"
+                        f"use '_{_key.lstrip('_')}_<suffix>' for mid-mapping placement"
                     )
             elif _key in ("_include_post", "_use_post"):
                 if _last_non_dir is not None and _i < _last_non_dir:

--- a/scabha/configuratt/core.py
+++ b/scabha/configuratt/core.py
@@ -304,7 +304,13 @@ def resolve_config_refs(
                     if include_directive is None:
                         return None
                     # get corresponding _scrub or _scrub_post directive
-                    scrub = pop_conf(conf, keyword.replace("include", "scrub"), None)
+                    if keyword == "_include":
+                        scrub_key = "_scrub"
+                    elif keyword == "_include_post":
+                        scrub_key = "_scrub_post"
+                    else:
+                        scrub_key = "_scrub_" + keyword[len("_include_") :]
+                    scrub = pop_conf(conf, scrub_key, None)
                     if isinstance(scrub, str):
                         scrub = [scrub]
 
@@ -475,7 +481,13 @@ def resolve_config_refs(
                     merge_sections = pop_conf(conf, keyword, None)
                     if merge_sections is None:
                         return None
-                    scrub = pop_conf(conf, keyword.replace("use", "scrub"), None)
+                    if keyword == "_use":
+                        scrub_key = "_scrub"
+                    elif keyword == "_use_post":
+                        scrub_key = "_scrub_post"
+                    else:
+                        scrub_key = "_scrub_" + keyword[len("_use_") :]
+                    scrub = pop_conf(conf, scrub_key, None)
                     if type(merge_sections) is str:
                         merge_sections = [merge_sections]
                     elif not isinstance(merge_sections, Sequence):

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -192,3 +192,69 @@ def test_arbitrary_placement(tmp_path):
     assert "keep_key" in conf
     assert "remove_key" not in conf
     assert "step_a" in conf and "step_z" in conf
+
+
+def test_suffix_containing_keyword(tmp_path):
+    """Tests that suffixes containing 'include' or 'use' in their name don't corrupt scrub-key derivation.
+
+    Covers the bug where `keyword.replace("include", "scrub")` would transform
+    `_include_subinclude` → `_scrub_subscrub` instead of `_scrub_subinclude`, and
+    `_use_reuse` → `_scrub_rescrub` instead of `_scrub_reuse`.
+    """
+    # -------------------------------------------------------------------------
+    # 1. _include_subinclude: suffix contains "include"
+    # -------------------------------------------------------------------------
+    included_file = tmp_path / "subinclude_source.yaml"
+    included_file.write_text("keep_key:\n  val: 1\nremove_key:\n  val: 2\n")
+
+    parent_file = tmp_path / "parent_subinclude.yaml"
+    parent_file.write_text(
+        f"step_a:\n  x: 1\n_include_subinclude: {included_file}\n_scrub_subinclude: remove_key\nstep_z:\n  x: 2\n"
+    )
+
+    conf, _ = configuratt.load(str(parent_file), use_sources=[], verbose=False, use_cache=False)
+
+    # Directive key must not survive
+    assert "_include_subinclude" not in conf
+    assert "_scrub_subinclude" not in conf
+
+    # Included content is present in-place (minus scrubbed key)
+    assert "keep_key" in conf
+    assert "remove_key" not in conf
+
+    # Surrounding keys survive
+    assert conf.step_a.x == 1
+    assert conf.step_z.x == 2
+
+    # Insertion order: step_a, keep_key, step_z
+    key_order = list(conf.keys())
+    assert key_order.index("step_a") < key_order.index("keep_key") < key_order.index("step_z")
+
+    # -------------------------------------------------------------------------
+    # 2. _use_reuse: suffix contains "use"
+    # -------------------------------------------------------------------------
+    use_file = tmp_path / "use_reuse.yaml"
+    use_file.write_text(
+        "lib:\n  common:\n    keep_val: 99\n    drop_val: 0\n\n"
+        "steps:\n  step_a:\n    x: 1\n  _use_reuse: lib.common\n  _scrub_reuse: drop_val\n  step_z:\n    x: 2\n"
+    )
+
+    conf, _ = configuratt.load(str(use_file), use_sources=[], verbose=False, use_cache=False)
+
+    steps = conf.steps
+
+    # Directive keys must not survive
+    assert "_use_reuse" not in steps
+    assert "_scrub_reuse" not in steps
+
+    # Used content is present in-place (minus scrubbed key)
+    assert "keep_val" in steps
+    assert "drop_val" not in steps
+
+    # Surrounding keys survive
+    assert steps.step_a.x == 1
+    assert steps.step_z.x == 2
+
+    # Insertion order: step_a, keep_val, step_z
+    key_order = list(steps.keys())
+    assert key_order.index("step_a") < key_order.index("keep_val") < key_order.index("step_z")

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -104,6 +104,10 @@ def test_arbitrary_placement(tmp_path):
     # No directive key should survive in the output
     assert "_include_middle" not in conf
 
+    # Keys must appear in insertion order: step_a, then mid_key1, then step_z
+    key_order = list(conf.keys())
+    assert key_order.index("step_a") < key_order.index("mid_key1") < key_order.index("step_z")
+
     # -------------------------------------------------------------------------
     # 2. _use_SUFFIX: in-place insertion (self-referencing config)
     # The loaded config is prepended to use_sources=[] so it is the only source.
@@ -131,6 +135,10 @@ def test_arbitrary_placement(tmp_path):
     # Directive key must not survive
     assert "_use_common" not in steps
 
+    # Keys must appear in insertion order: step_a, then val, then step_z
+    key_order = list(steps.keys())
+    assert key_order.index("step_a") < key_order.index("val") < key_order.index("step_z")
+
     # -------------------------------------------------------------------------
     # 3. Placement error: _include after content keys raises ConfigurattError
     # -------------------------------------------------------------------------
@@ -155,12 +163,13 @@ def test_arbitrary_placement(tmp_path):
 
     # -------------------------------------------------------------------------
     # 5. _use_post is still treated as post-only, not as arbitrary-suffix
-    #    (i.e., _use_post with content before it raises ConfigurattError)
+    #    (i.e., _use_post is invalid when it has content after it — it must be
+    #    at the bottom; content before it is fine)
     # -------------------------------------------------------------------------
     use_post_bad_file = tmp_path / "use_post_bad.yaml"
     use_post_src = tmp_path / "use_post_src.yaml"
     use_post_src.write_text("lib:\n  key: 1\n")
-    # _use_post appearing before content should raise a placement error
+    # _use_post appearing before content (i.e., not at the bottom) should raise a placement error
     use_post_bad_file.write_text("_use_post: lib\nstep_a:\n  x: 1\n")
 
     # Load with the source config that contains lib

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -70,3 +70,100 @@ def test_tilde_include(tmp_path):
         assert conf.tilde_included.value == 42
     finally:
         include_file.unlink(missing_ok=True)
+
+
+def test_arbitrary_placement(tmp_path):
+    """Tests for _include_SUFFIX / _use_SUFFIX in-place insertion and placement enforcement."""
+
+    # -------------------------------------------------------------------------
+    # 1. _include_SUFFIX: in-place insertion
+    # Write a file to be included, then a parent that includes it in the middle.
+    # -------------------------------------------------------------------------
+    included_file = tmp_path / "middle.yaml"
+    included_file.write_text("mid_key1:\n  val: 10\nmid_key2:\n  val: 20\n")
+
+    parent_file = tmp_path / "parent_include.yaml"
+    parent_file.write_text(
+        f"step_a:\n  command: prep\n_include_middle: {included_file}\nstep_z:\n  command: finalize\n"
+    )
+
+    conf, _ = configuratt.load(str(parent_file), use_sources=[], verbose=False, use_cache=False)
+
+    # All keys must be present
+    assert "step_a" in conf
+    assert "mid_key1" in conf
+    assert "mid_key2" in conf
+    assert "step_z" in conf
+
+    # Values must be correct
+    assert conf.step_a.command == "prep"
+    assert conf.mid_key1.val == 10
+    assert conf.mid_key2.val == 20
+    assert conf.step_z.command == "finalize"
+
+    # No directive key should survive in the output
+    assert "_include_middle" not in conf
+
+    # -------------------------------------------------------------------------
+    # 2. _use_SUFFIX: in-place insertion (self-referencing config)
+    # The loaded config is prepended to use_sources=[] so it is the only source.
+    # -------------------------------------------------------------------------
+    use_file = tmp_path / "use_inplace.yaml"
+    use_file.write_text(
+        "lib:\n  common:\n    val: 99\n\nsteps:\n  step_a:\n    x: 1\n  _use_common: lib.common\n  step_z:\n    x: 2\n"
+    )
+
+    conf, _ = configuratt.load(str(use_file), use_sources=[], verbose=False, use_cache=False)
+
+    # lib section is still present at top level
+    assert "lib" in conf
+
+    # steps section should have step_a, val (from lib.common), and step_z
+    steps = conf.steps
+    assert "step_a" in steps
+    assert "val" in steps
+    assert "step_z" in steps
+
+    assert steps.step_a.x == 1
+    assert steps.val == 99
+    assert steps.step_z.x == 2
+
+    # Directive key must not survive
+    assert "_use_common" not in steps
+
+    # -------------------------------------------------------------------------
+    # 3. Placement error: _include after content keys raises ConfigurattError
+    # -------------------------------------------------------------------------
+    bad_include_file = tmp_path / "bad_include_top.yaml"
+    # We need an included file that at least exists (content doesn't matter for this error)
+    dummy_included = tmp_path / "dummy.yaml"
+    dummy_included.write_text("x: 1\n")
+
+    bad_include_file.write_text(f"step_a:\n  command: prep\n_include: {dummy_included}\n")
+
+    with pytest.raises(ConfigurattError, match="_include"):
+        configuratt.load(str(bad_include_file), use_sources=[], verbose=False, use_cache=False)
+
+    # -------------------------------------------------------------------------
+    # 4. Placement error: _include_post before last content key raises ConfigurattError
+    # -------------------------------------------------------------------------
+    bad_post_file = tmp_path / "bad_include_post.yaml"
+    bad_post_file.write_text(f"_include_post: {dummy_included}\nstep_a:\n  command: prep\n")
+
+    with pytest.raises(ConfigurattError, match="_include_post"):
+        configuratt.load(str(bad_post_file), use_sources=[], verbose=False, use_cache=False)
+
+    # -------------------------------------------------------------------------
+    # 5. _use_post is still treated as post-only, not as arbitrary-suffix
+    #    (i.e., _use_post with content before it raises ConfigurattError)
+    # -------------------------------------------------------------------------
+    use_post_bad_file = tmp_path / "use_post_bad.yaml"
+    use_post_src = tmp_path / "use_post_src.yaml"
+    use_post_src.write_text("lib:\n  key: 1\n")
+    # _use_post appearing before content should raise a placement error
+    use_post_bad_file.write_text("_use_post: lib\nstep_a:\n  x: 1\n")
+
+    # Load with the source config that contains lib
+    src_conf = OmegaConf.load(str(use_post_src))
+    with pytest.raises(ConfigurattError, match="_use_post"):
+        configuratt.load(str(use_post_bad_file), use_sources=[src_conf], verbose=False, use_cache=False)

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -270,3 +270,106 @@ def test_use_suffix_with_use_in_name(tmp_path):
 
     key_order = list(steps.keys())
     assert key_order.index("step_a") < key_order.index("keep_val") < key_order.index("step_z")
+
+
+# ---------------------------------------------------------------------------
+# Positional priority semantics
+# ---------------------------------------------------------------------------
+# All directives (_include, _include_SUFFIX, _include_post, _use, _use_SUFFIX,
+# _use_post) follow the same rule: later in the mapping = higher priority.
+# The tests below check collision resolution at each position.
+
+
+def test_include_top_loses_to_content(tmp_path):
+    """_include at the top: content keys in the parent win on conflict."""
+    inc = tmp_path / "base.yaml"
+    inc.write_text("shared: from_include\nunique_inc: 1\n")
+
+    parent = tmp_path / "parent.yaml"
+    parent.write_text(f"_include: {inc}\nshared: from_parent\nunique_parent: 2\n")
+
+    conf, _ = configuratt.load(str(parent), use_sources=[], verbose=False, use_cache=False)
+
+    assert conf.shared == "from_parent"  # parent wins
+    assert conf.unique_inc == 1  # non-conflicting key from include survives
+    assert conf.unique_parent == 2
+
+
+def test_include_post_wins_over_content(tmp_path):
+    """_include_post at the bottom: included content wins on conflict."""
+    inc = tmp_path / "override.yaml"
+    inc.write_text("shared: from_post\nunique_post: 9\n")
+
+    parent = tmp_path / "parent.yaml"
+    parent.write_text(f"shared: from_parent\nunique_parent: 1\n_include_post: {inc}\n")
+
+    conf, _ = configuratt.load(str(parent), use_sources=[], verbose=False, use_cache=False)
+
+    assert conf.shared == "from_post"  # _include_post wins
+    assert conf.unique_parent == 1  # non-conflicting key from parent survives
+    assert conf.unique_post == 9
+
+
+def test_include_suffix_positional_priority(tmp_path):
+    """_include_SUFFIX: wins over keys before it, loses to keys after it."""
+    inc = tmp_path / "middle.yaml"
+    inc.write_text("before_key: from_include\nafter_key: from_include\nunique_mid: 42\n")
+
+    parent = tmp_path / "parent.yaml"
+    # before_key appears before the directive → include wins
+    # after_key appears after the directive → parent wins
+    parent.write_text(f"before_key: from_parent\n_include_mid: {inc}\nafter_key: from_parent\n")
+
+    conf, _ = configuratt.load(str(parent), use_sources=[], verbose=False, use_cache=False)
+
+    assert conf.before_key == "from_include"  # include overrides earlier key
+    assert conf.after_key == "from_parent"  # later key overrides include
+    assert conf.unique_mid == 42
+
+
+def test_use_top_loses_to_content(tmp_path):
+    """_use at the top: content keys in the current section win on conflict."""
+    lib = tmp_path / "lib.yaml"
+    lib.write_text("base:\n  shared: from_base\n  unique_base: 1\n")
+    lib_conf = OmegaConf.load(str(lib))
+
+    parent = tmp_path / "parent.yaml"
+    parent.write_text("_use: base\nshared: from_parent\nunique_parent: 2\n")
+
+    conf, _ = configuratt.load(str(parent), use_sources=[lib_conf], verbose=False, use_cache=False)
+
+    assert conf.shared == "from_parent"  # parent wins
+    assert conf.unique_base == 1  # non-conflicting key from base survives
+    assert conf.unique_parent == 2
+
+
+def test_use_post_wins_over_content(tmp_path):
+    """_use_post at the bottom: referenced section wins on conflict."""
+    lib = tmp_path / "lib.yaml"
+    lib.write_text("override:\n  shared: from_post\n  unique_post: 9\n")
+    lib_conf = OmegaConf.load(str(lib))
+
+    parent = tmp_path / "parent.yaml"
+    parent.write_text("shared: from_parent\nunique_parent: 1\n_use_post: override\n")
+
+    conf, _ = configuratt.load(str(parent), use_sources=[lib_conf], verbose=False, use_cache=False)
+
+    assert conf.shared == "from_post"  # _use_post wins
+    assert conf.unique_parent == 1
+    assert conf.unique_post == 9
+
+
+def test_use_suffix_positional_priority(tmp_path):
+    """_use_SUFFIX: wins over keys before it, loses to keys after it."""
+    lib = tmp_path / "lib.yaml"
+    lib.write_text("section:\n  before_key: from_use\n  after_key: from_use\n  unique_mid: 99\n")
+    lib_conf = OmegaConf.load(str(lib))
+
+    parent = tmp_path / "parent.yaml"
+    parent.write_text("before_key: from_parent\n_use_mid: section\nafter_key: from_parent\n")
+
+    conf, _ = configuratt.load(str(parent), use_sources=[lib_conf], verbose=False, use_cache=False)
+
+    assert conf.before_key == "from_use"  # use overrides earlier key
+    assert conf.after_key == "from_parent"  # later key overrides use
+    assert conf.unique_mid == 99

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -133,6 +133,19 @@ def test_include_after_content_raises_error(tmp_path):
         configuratt.load(str(bad_include_file), use_sources=[], verbose=False, use_cache=False)
 
 
+def test_use_after_content_raises_error(tmp_path):
+    """Bare _use after content keys raises ConfigurattError."""
+    lib = tmp_path / "lib.yaml"
+    lib.write_text("base:\n  x: 1\n")
+    lib_conf = OmegaConf.load(str(lib))
+
+    bad_use_file = tmp_path / "bad_use_top.yaml"
+    bad_use_file.write_text("step_a:\n  command: prep\n_use: base\n")
+
+    with pytest.raises(ConfigurattError, match="_use"):
+        configuratt.load(str(bad_use_file), use_sources=[lib_conf], verbose=False, use_cache=False)
+
+
 def test_include_post_placement_error(tmp_path):
     """_include_post before last content key raises ConfigurattError."""
     dummy_included = tmp_path / "dummy.yaml"

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -233,6 +233,31 @@ def test_arbitrary_placement(tmp_path):
     with pytest.raises(ConfigurattError, match="_include_post"):
         configuratt.load(str(post_then_mid_file), use_sources=[], verbose=False, use_cache=False)
 
+    # -------------------------------------------------------------------------
+    # 9. Recursive resolution: content brought in via _use_SUFFIX must itself
+    #    be fully resolved (nested _use directives inside the referenced section
+    #    must be processed, not left as raw keys in the output).
+    # -------------------------------------------------------------------------
+    lib_recursive = tmp_path / "lib_recursive.yaml"
+    lib_recursive.write_text("base:\n  deep_val: 99\nstep:\n  _use: base\n  x: 1\n")
+
+    lib_conf = OmegaConf.load(str(lib_recursive))
+
+    use_recursive_parent = tmp_path / "parent_use_recursive.yaml"
+    use_recursive_parent.write_text("before: 1\n_use_mid: step\nafter: 2\n")
+
+    conf, _ = configuratt.load(str(use_recursive_parent), use_sources=[lib_conf], verbose=False, use_cache=False)
+
+    # Keys from the nested _use must be present after recursive resolution
+    assert conf.before == 1
+    assert conf.x == 1
+    assert conf.deep_val == 99
+    assert conf.after == 2
+
+    # Directive key must not survive
+    assert "_use_mid" not in conf
+    assert "_use" not in conf
+
 
 def test_suffix_containing_keyword(tmp_path):
     """Tests that suffixes containing 'include' or 'use' in their name don't corrupt scrub-key derivation.

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -72,13 +72,8 @@ def test_tilde_include(tmp_path):
         include_file.unlink(missing_ok=True)
 
 
-def test_arbitrary_placement(tmp_path):
-    """Tests for _include_SUFFIX / _use_SUFFIX in-place insertion and placement enforcement."""
-
-    # -------------------------------------------------------------------------
-    # 1. _include_SUFFIX: in-place insertion
-    # Write a file to be included, then a parent that includes it in the middle.
-    # -------------------------------------------------------------------------
+def test_include_suffix_inplace_insertion(tmp_path):
+    """_include_SUFFIX inserts included keys at the directive's position."""
     included_file = tmp_path / "middle.yaml"
     included_file.write_text("mid_key1:\n  val: 10\nmid_key2:\n  val: 20\n")
 
@@ -89,29 +84,22 @@ def test_arbitrary_placement(tmp_path):
 
     conf, _ = configuratt.load(str(parent_file), use_sources=[], verbose=False, use_cache=False)
 
-    # All keys must be present
     assert "step_a" in conf
     assert "mid_key1" in conf
     assert "mid_key2" in conf
     assert "step_z" in conf
-
-    # Values must be correct
     assert conf.step_a.command == "prep"
     assert conf.mid_key1.val == 10
     assert conf.mid_key2.val == 20
     assert conf.step_z.command == "finalize"
-
-    # No directive key should survive in the output
     assert "_include_middle" not in conf
 
-    # Keys must appear in insertion order: step_a, then mid_key1, then step_z
     key_order = list(conf.keys())
     assert key_order.index("step_a") < key_order.index("mid_key1") < key_order.index("step_z")
 
-    # -------------------------------------------------------------------------
-    # 2. _use_SUFFIX: in-place insertion (self-referencing config)
-    # The loaded config is prepended to use_sources=[] so it is the only source.
-    # -------------------------------------------------------------------------
+
+def test_use_suffix_inplace_insertion(tmp_path):
+    """_use_SUFFIX inserts referenced section's keys at the directive's position."""
     use_file = tmp_path / "use_inplace.yaml"
     use_file.write_text(
         "lib:\n  common:\n    val: 99\n\nsteps:\n  step_a:\n    x: 1\n  _use_common: lib.common\n  step_z:\n    x: 2\n"
@@ -119,67 +107,58 @@ def test_arbitrary_placement(tmp_path):
 
     conf, _ = configuratt.load(str(use_file), use_sources=[], verbose=False, use_cache=False)
 
-    # lib section is still present at top level
     assert "lib" in conf
-
-    # steps section should have step_a, val (from lib.common), and step_z
     steps = conf.steps
     assert "step_a" in steps
     assert "val" in steps
     assert "step_z" in steps
-
     assert steps.step_a.x == 1
     assert steps.val == 99
     assert steps.step_z.x == 2
-
-    # Directive key must not survive
     assert "_use_common" not in steps
 
-    # Keys must appear in insertion order: step_a, then val, then step_z
     key_order = list(steps.keys())
     assert key_order.index("step_a") < key_order.index("val") < key_order.index("step_z")
 
-    # -------------------------------------------------------------------------
-    # 3. Placement error: _include after content keys raises ConfigurattError
-    # -------------------------------------------------------------------------
-    bad_include_file = tmp_path / "bad_include_top.yaml"
-    # We need an included file that at least exists (content doesn't matter for this error)
+
+def test_include_after_content_raises_error(tmp_path):
+    """Bare _include after content keys raises ConfigurattError."""
     dummy_included = tmp_path / "dummy.yaml"
     dummy_included.write_text("x: 1\n")
 
+    bad_include_file = tmp_path / "bad_include_top.yaml"
     bad_include_file.write_text(f"step_a:\n  command: prep\n_include: {dummy_included}\n")
 
     with pytest.raises(ConfigurattError, match="_include"):
         configuratt.load(str(bad_include_file), use_sources=[], verbose=False, use_cache=False)
 
-    # -------------------------------------------------------------------------
-    # 4. Placement error: _include_post before last content key raises ConfigurattError
-    # -------------------------------------------------------------------------
+
+def test_include_post_placement_error(tmp_path):
+    """_include_post before last content key raises ConfigurattError."""
+    dummy_included = tmp_path / "dummy.yaml"
+    dummy_included.write_text("x: 1\n")
+
     bad_post_file = tmp_path / "bad_include_post.yaml"
     bad_post_file.write_text(f"_include_post: {dummy_included}\nstep_a:\n  command: prep\n")
 
     with pytest.raises(ConfigurattError, match="_include_post"):
         configuratt.load(str(bad_post_file), use_sources=[], verbose=False, use_cache=False)
 
-    # -------------------------------------------------------------------------
-    # 5. _use_post is still treated as post-only, not as arbitrary-suffix
-    #    (i.e., _use_post is invalid when it has content after it — it must be
-    #    at the bottom; content before it is fine)
-    # -------------------------------------------------------------------------
-    use_post_bad_file = tmp_path / "use_post_bad.yaml"
+
+def test_use_post_placement_error(tmp_path):
+    """_use_post before last content key raises ConfigurattError."""
     use_post_src = tmp_path / "use_post_src.yaml"
     use_post_src.write_text("lib:\n  key: 1\n")
-    # _use_post appearing before content (i.e., not at the bottom) should raise a placement error
+    use_post_bad_file = tmp_path / "use_post_bad.yaml"
     use_post_bad_file.write_text("_use_post: lib\nstep_a:\n  x: 1\n")
 
-    # Load with the source config that contains lib
     src_conf = OmegaConf.load(str(use_post_src))
     with pytest.raises(ConfigurattError, match="_use_post"):
         configuratt.load(str(use_post_bad_file), use_sources=[src_conf], verbose=False, use_cache=False)
 
-    # -------------------------------------------------------------------------
-    # 6. _scrub_SUFFIX scrubs keys from the corresponding _include_SUFFIX result
-    # -------------------------------------------------------------------------
+
+def test_include_suffix_scrub(tmp_path):
+    """_scrub_SUFFIX removes specified keys from the corresponding _include_SUFFIX result."""
     scrub_included = tmp_path / "scrub_source.yaml"
     scrub_included.write_text("keep_key:\n  val: 1\nremove_key:\n  val: 2\n")
 
@@ -193,11 +172,9 @@ def test_arbitrary_placement(tmp_path):
     assert "remove_key" not in conf
     assert "step_a" in conf and "step_z" in conf
 
-    # -------------------------------------------------------------------------
-    # 7. Recursive resolution: content brought in via _include_SUFFIX must itself
-    #    be fully resolved (nested _include directives inside the included file
-    #    must be processed, not left as raw keys in the output).
-    # -------------------------------------------------------------------------
+
+def test_include_suffix_recursive(tmp_path):
+    """Content brought in via _include_SUFFIX is itself fully resolved."""
     grandchild_file = tmp_path / "grandchild.yaml"
     grandchild_file.write_text("deep_key: 42\n")
 
@@ -209,35 +186,29 @@ def test_arbitrary_placement(tmp_path):
 
     conf, _ = configuratt.load(str(parent_recursive), use_sources=[], verbose=False, use_cache=False)
 
-    # Keys from all three levels must be present
     assert "before_key" in conf
     assert "mid_key" in conf
     assert "deep_key" in conf
     assert "after_key" in conf
-
-    # Grandchild value must be correct (recursively resolved)
     assert conf.deep_key == 42
-
-    # No directive keys must survive
     assert "_include_mid" not in conf
     assert "_include" not in conf
 
-    # -------------------------------------------------------------------------
-    # 8. Placement error: _include_mid after _include_post raises ConfigurattError.
-    #    In-place directives (like _include_mid) are not content keys but they
-    #    must still not appear after a _include_post / _use_post directive.
-    # -------------------------------------------------------------------------
+
+def test_include_suffix_after_post_raises_error(tmp_path):
+    """_include_SUFFIX appearing after _include_post raises ConfigurattError."""
+    dummy_included = tmp_path / "dummy.yaml"
+    dummy_included.write_text("x: 1\n")
+
     post_then_mid_file = tmp_path / "post_then_mid.yaml"
     post_then_mid_file.write_text(f"content_key: 1\n_include_post: {dummy_included}\n_include_mid: {dummy_included}\n")
 
     with pytest.raises(ConfigurattError, match="_include_post"):
         configuratt.load(str(post_then_mid_file), use_sources=[], verbose=False, use_cache=False)
 
-    # -------------------------------------------------------------------------
-    # 9. Recursive resolution: content brought in via _use_SUFFIX must itself
-    #    be fully resolved (nested _use directives inside the referenced section
-    #    must be processed, not left as raw keys in the output).
-    # -------------------------------------------------------------------------
+
+def test_use_suffix_recursive(tmp_path):
+    """Content brought in via _use_SUFFIX is itself fully resolved."""
     lib_recursive = tmp_path / "lib_recursive.yaml"
     lib_recursive.write_text("base:\n  deep_val: 99\nstep:\n  _use: base\n  x: 1\n")
 
@@ -248,27 +219,16 @@ def test_arbitrary_placement(tmp_path):
 
     conf, _ = configuratt.load(str(use_recursive_parent), use_sources=[lib_conf], verbose=False, use_cache=False)
 
-    # Keys from the nested _use must be present after recursive resolution
     assert conf.before == 1
     assert conf.x == 1
     assert conf.deep_val == 99
     assert conf.after == 2
-
-    # Directive key must not survive
     assert "_use_mid" not in conf
     assert "_use" not in conf
 
 
-def test_suffix_containing_keyword(tmp_path):
-    """Tests that suffixes containing 'include' or 'use' in their name don't corrupt scrub-key derivation.
-
-    Covers the bug where `keyword.replace("include", "scrub")` would transform
-    `_include_subinclude` → `_scrub_subscrub` instead of `_scrub_subinclude`, and
-    `_use_reuse` → `_scrub_rescrub` instead of `_scrub_reuse`.
-    """
-    # -------------------------------------------------------------------------
-    # 1. _include_subinclude: suffix contains "include"
-    # -------------------------------------------------------------------------
+def test_include_suffix_with_include_in_name(tmp_path):
+    """Suffix containing 'include' doesn't corrupt _scrub key derivation."""
     included_file = tmp_path / "subinclude_source.yaml"
     included_file.write_text("keep_key:\n  val: 1\nremove_key:\n  val: 2\n")
 
@@ -279,25 +239,19 @@ def test_suffix_containing_keyword(tmp_path):
 
     conf, _ = configuratt.load(str(parent_file), use_sources=[], verbose=False, use_cache=False)
 
-    # Directive key must not survive
     assert "_include_subinclude" not in conf
     assert "_scrub_subinclude" not in conf
-
-    # Included content is present in-place (minus scrubbed key)
     assert "keep_key" in conf
     assert "remove_key" not in conf
-
-    # Surrounding keys survive
     assert conf.step_a.x == 1
     assert conf.step_z.x == 2
 
-    # Insertion order: step_a, keep_key, step_z
     key_order = list(conf.keys())
     assert key_order.index("step_a") < key_order.index("keep_key") < key_order.index("step_z")
 
-    # -------------------------------------------------------------------------
-    # 2. _use_reuse: suffix contains "use"
-    # -------------------------------------------------------------------------
+
+def test_use_suffix_with_use_in_name(tmp_path):
+    """Suffix containing 'use' doesn't corrupt _scrub key derivation."""
     use_file = tmp_path / "use_reuse.yaml"
     use_file.write_text(
         "lib:\n  common:\n    keep_val: 99\n    drop_val: 0\n\n"
@@ -307,19 +261,12 @@ def test_suffix_containing_keyword(tmp_path):
     conf, _ = configuratt.load(str(use_file), use_sources=[], verbose=False, use_cache=False)
 
     steps = conf.steps
-
-    # Directive keys must not survive
     assert "_use_reuse" not in steps
     assert "_scrub_reuse" not in steps
-
-    # Used content is present in-place (minus scrubbed key)
     assert "keep_val" in steps
     assert "drop_val" not in steps
-
-    # Surrounding keys survive
     assert steps.step_a.x == 1
     assert steps.step_z.x == 2
 
-    # Insertion order: step_a, keep_val, step_z
     key_order = list(steps.keys())
     assert key_order.index("step_a") < key_order.index("keep_val") < key_order.index("step_z")

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -176,3 +176,19 @@ def test_arbitrary_placement(tmp_path):
     src_conf = OmegaConf.load(str(use_post_src))
     with pytest.raises(ConfigurattError, match="_use_post"):
         configuratt.load(str(use_post_bad_file), use_sources=[src_conf], verbose=False, use_cache=False)
+
+    # -------------------------------------------------------------------------
+    # 6. _scrub_SUFFIX scrubs keys from the corresponding _include_SUFFIX result
+    # -------------------------------------------------------------------------
+    scrub_included = tmp_path / "scrub_source.yaml"
+    scrub_included.write_text("keep_key:\n  val: 1\nremove_key:\n  val: 2\n")
+
+    scrub_parent = tmp_path / "parent_scrub.yaml"
+    scrub_parent.write_text(
+        f"step_a:\n  x: 1\n_include_mid: {scrub_included}\n_scrub_mid: remove_key\nstep_z:\n  x: 2\n"
+    )
+
+    conf, _ = configuratt.load(str(scrub_parent), use_sources=[], verbose=False, use_cache=False)
+    assert "keep_key" in conf
+    assert "remove_key" not in conf
+    assert "step_a" in conf and "step_z" in conf

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -222,6 +222,17 @@ def test_arbitrary_placement(tmp_path):
     assert "_include_mid" not in conf
     assert "_include" not in conf
 
+    # -------------------------------------------------------------------------
+    # 8. Placement error: _include_mid after _include_post raises ConfigurattError.
+    #    In-place directives (like _include_mid) are not content keys but they
+    #    must still not appear after a _include_post / _use_post directive.
+    # -------------------------------------------------------------------------
+    post_then_mid_file = tmp_path / "post_then_mid.yaml"
+    post_then_mid_file.write_text(f"content_key: 1\n_include_post: {dummy_included}\n_include_mid: {dummy_included}\n")
+
+    with pytest.raises(ConfigurattError, match="_include_post"):
+        configuratt.load(str(post_then_mid_file), use_sources=[], verbose=False, use_cache=False)
+
 
 def test_suffix_containing_keyword(tmp_path):
     """Tests that suffixes containing 'include' or 'use' in their name don't corrupt scrub-key derivation.

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -193,6 +193,35 @@ def test_arbitrary_placement(tmp_path):
     assert "remove_key" not in conf
     assert "step_a" in conf and "step_z" in conf
 
+    # -------------------------------------------------------------------------
+    # 7. Recursive resolution: content brought in via _include_SUFFIX must itself
+    #    be fully resolved (nested _include directives inside the included file
+    #    must be processed, not left as raw keys in the output).
+    # -------------------------------------------------------------------------
+    grandchild_file = tmp_path / "grandchild.yaml"
+    grandchild_file.write_text("deep_key: 42\n")
+
+    middle_file = tmp_path / "middle_recursive.yaml"
+    middle_file.write_text(f"_include: {grandchild_file}\nmid_key: hello\n")
+
+    parent_recursive = tmp_path / "parent_recursive.yaml"
+    parent_recursive.write_text(f"before_key: 1\n_include_mid: {middle_file}\nafter_key: 2\n")
+
+    conf, _ = configuratt.load(str(parent_recursive), use_sources=[], verbose=False, use_cache=False)
+
+    # Keys from all three levels must be present
+    assert "before_key" in conf
+    assert "mid_key" in conf
+    assert "deep_key" in conf
+    assert "after_key" in conf
+
+    # Grandchild value must be correct (recursively resolved)
+    assert conf.deep_key == 42
+
+    # No directive keys must survive
+    assert "_include_mid" not in conf
+    assert "_include" not in conf
+
 
 def test_suffix_containing_keyword(tmp_path):
     """Tests that suffixes containing 'include' or 'use' in their name don't corrupt scrub-key derivation.

--- a/tests/test_configuratt.py
+++ b/tests/test_configuratt.py
@@ -146,6 +146,25 @@ def test_use_after_content_raises_error(tmp_path):
         configuratt.load(str(bad_use_file), use_sources=[lib_conf], verbose=False, use_cache=False)
 
 
+def test_orphaned_scrub_raises_error(tmp_path):
+    """_scrub_<suffix> with no matching _include_<suffix> or _use_<suffix> raises ConfigurattError."""
+    # orphaned _scrub_foo — no _include_foo or _use_foo
+    bad_file = tmp_path / "orphan_scrub.yaml"
+    bad_file.write_text("a: 1\n_scrub_foo: some_key\nb: 2\n")
+
+    with pytest.raises(ConfigurattError, match="_scrub_foo"):
+        configuratt.load(str(bad_file), use_sources=[], verbose=False, use_cache=False)
+
+
+def test_orphaned_bare_scrub_raises_error(tmp_path):
+    """Bare _scrub with no matching _include or _use raises ConfigurattError."""
+    bad_file = tmp_path / "orphan_bare_scrub.yaml"
+    bad_file.write_text("a: 1\n_scrub: some_key\nb: 2\n")
+
+    with pytest.raises(ConfigurattError, match="_scrub"):
+        configuratt.load(str(bad_file), use_sources=[], verbose=False, use_cache=False)
+
+
 def test_include_post_placement_error(tmp_path):
     """_include_post before last content key raises ConfigurattError."""
     dummy_included = tmp_path / "dummy.yaml"

--- a/tests/test_include2.yaml
+++ b/tests/test_include2.yaml
@@ -1,5 +1,4 @@
 x:
+  _include: test_include
   y: a
   z: b
-  _include: test_include
-  


### PR DESCRIPTION
## Summary

- Adds `_include_SUFFIX` and `_use_SUFFIX` directives (e.g. `_use_imaging_steps`, `_include_calibration`) that insert included/used content **at the position they appear** in the mapping
- Enforces that plain `_include`/`_use` may only appear at the **top** of a mapping, and `_include_post`/`_use_post` only at the **bottom** — violating this now raises a `ConfigurattError`

## Motivation

Previously, there was no way to interleave included steps in the middle of a recipe. Users had to resort to splitting into multiple sub-recipes. Now:

```yaml
recipe:
  steps:
    prep_step:
      cab: some-prep-tool

    _use_imaging: lib.imaging_steps        # these steps come here in execution order

    _include_calibration: calibration.yml  # these steps come here

    final_step:
      cab: some-final-tool
```

## Behaviour

| Directive | Semantics |
|-----------|-----------|
| `_include` | pre-merge; **must appear at top** before any content keys |
| `_include_post` | post-merge; **must appear at bottom** after all content keys |
| `_include_SUFFIX` | in-place insertion at the position it appears |
| `_use` | pre-merge; **must appear at top** |
| `_use_post` | post-merge; **must appear at bottom** |
| `_use_SUFFIX` | in-place insertion at the position it appears |

Corresponding `_scrub_SUFFIX` keys are honoured for `_include_SUFFIX` and `_use_SUFFIX`.

## Breaking change

Previously, `_include`/`_use` could appear anywhere in a mapping without error (the placement was silently ignored — they always acted as pre-merges). Files that relied on this misleading behaviour will now get a `ConfigurattError` directing the author to use `_include_SUFFIX` instead.

## Test plan

- [ ] `_use_xxx` inserts steps in the correct execution order
- [ ] `_include_xxx` inserts file content at the correct position
- [ ] `_include` before content keys works as before
- [ ] `_include` after content keys raises `ConfigurattError`
- [ ] `_include_post` before content keys raises `ConfigurattError`
- [ ] `_include_post` after content keys works as before
- [ ] Content brought in by `_use_xxx` / `_include_xxx` is recursively resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)