### PR TITLE
ci: fix test workflow to run on master branch PRs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -378,7 +378,9 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                 # for positional arguments, default metavar to the parameter name
                 # rather than dtype, which is more informative (fixes stimela#424)
                 pos_metavar = schema.metavar or name.upper()
-                kwargs.update(type=dtype, callback=validator, required=schema.required, nargs=nargs, metavar=pos_metavar)
+                kwargs.update(
+                    type=dtype, callback=validator, required=schema.required, nargs=nargs, metavar=pos_metavar
+                )
                 deco = click.argument(name, **kwargs)
             else:
                 kwargs.update(


### PR DESCRIPTION
## Summary

- The existing `python-package.yml` workflow targeted `main`, but the repo's default branch is `master`, so CI never ran on pushes or pull requests
- Changed both `push` and `pull_request` triggers from `[ main ]` to `[ master ]`

The workflow already has everything needed — multi-Python matrix (3.9–3.13), ruff lint+format checks, and `uv run pytest tests` — it just wasn't firing.

## Test plan

- [ ] Open a PR against `master` and confirm the "Python package" check appears and runs
- [ ] Push a commit to `master` and confirm the workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)