### PR TITLE
Replace register_new_resolver with register_resolver due to pending deprecation.

### DIFF
--- a/src/scabha/configuratt/core.py
+++ b/src/scabha/configuratt/core.py
@@ -61,7 +61,7 @@ def load(
                 return self_namespace[arg]
             raise KeyError(f"invalid '${{self:arg}}' substitution in {path}")
 
-        OmegaConf.register_new_resolver("self", self_namespace_resolver)
+        OmegaConf.register_resolver("self", self_namespace_resolver)
         try:
             subconf = OmegaConf.load(path)
             # force resolution of interpolations at this point (otherwise they happen lazily)


### PR DESCRIPTION
Fixes #37. OmegaConf seems to have settled on a convention and `register_new_resolver` is scheduled for deprecation. This tiny change should prevent a large number of warning messages from appearing when running `load`.