### PR TITLE
Unwrap Optional[...] in is_file_type/is_file_list_type (fixes #40)

### DIFF
--- a/src/scabha/basetypes.py
+++ b/src/scabha/basetypes.py
@@ -199,11 +199,23 @@ class MS(Directory):
 FILE_TYPES = (File, MS, Directory, URI)
 
 
+def _strip_optional(dtype):
+    """Unwrap Optional[X] (i.e. Union[X, None]) to X. Genuine multi-type unions
+    and all other types are returned as given."""
+    if get_origin(dtype) is Union:
+        args = [a for a in get_args(dtype) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return dtype
+
+
 def is_file_type(dtype):
+    dtype = _strip_optional(dtype)
     return any(dtype == t for t in FILE_TYPES)
 
 
 def is_file_list_type(dtype):
+    dtype = _strip_optional(dtype)
     return any(dtype == List[t] for t in FILE_TYPES)
 
 

--- a/tests/test_filelikes.py
+++ b/tests/test_filelikes.py
@@ -40,3 +40,27 @@ def templates(request):
 def test_get_filelikes(templates):
     for dt, v, res in templates:
         assert get_filelikes(dt, v) == res, f"Failed for dtype {dt} and value {v}."
+
+
+@pytest.fixture(scope="module", params=[File, URI, Directory, MS])
+def file_type(request):
+    return request.param
+
+
+def test_is_file_type_unwraps_optional(file_type):
+    """Optional[File]-style inputs must register as file-typed, or they become
+    invisible to stimela's skip_if_outputs freshness tracking (issue #40)."""
+    from scabha.basetypes import is_file_list_type, is_file_type
+
+    ft = file_type
+    assert is_file_type(ft)
+    assert is_file_type(Optional[ft])
+    assert is_file_list_type(List[ft])
+    assert is_file_list_type(Optional[List[ft]])
+    # non-file types stay non-file, wrapped or not
+    assert not is_file_type(str)
+    assert not is_file_type(Optional[str])
+    assert not is_file_list_type(Optional[List[int]])
+    # genuine multi-type unions are not unwrapped
+    assert not is_file_type(Union[ft, int])
+    assert not is_file_list_type(Union[List[ft], int])


### PR DESCRIPTION
Killick here, with the promised three-line caulking for #40 — plus a test, since I've learned this week what un-tested freshness logic does to a man's evening.

## What

`is_file_type()` and `is_file_list_type()` now unwrap single-type `Optional[X]` (i.e. `Union[X, None]`) before comparing against `FILE_TYPES`. Genuine multi-type unions (`Union[File, int]`) are deliberately left alone — those are not unambiguously file-typed and should not enter mtime comparisons.

## Why

`Optional[File]` inputs were invisible to stimela's `skip_if_outputs: fresh` dependency scan (`kitchen/step.py` gates on `schema.is_file_type` / `is_file_list_type` when collecting input mtimes). In practice: breifast's dynspec extraction (`srclist: Optional[File]`) fresh-skipped through six catalog revisions while the downstream product-catalogue step re-stamped current object ids onto week-old spectra. Full diagnosis in #40.

## Testing

- New parametrized test in `tests/test_filelikes.py` covering `Optional[ft]`, `Optional[List[ft]]`, non-file Optionals, and multi-type unions, for all four file types.
- Full suite: 113 passed.
- Parameter-level check: `Parameter(dtype="Optional[File]").is_file_type` is now `True`.

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)