### PR TITLE
Fix clickify_parameters corrupting non-empty List/Tuple defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scabha"
-version = "2.2.0rc2"
+version = "2.2.0rc3"
 description = "Argument parser and validation tool for (not just) radio interferometry"
 authors = [
     { name = "Oleg Smirnov and RATT", email = "osmirnov@gmail.com" },

--- a/src/scabha/schema_utils.py
+++ b/src/scabha/schema_utils.py
@@ -127,21 +127,43 @@ def nested_schema_to_dataclass(nested: Dict[str, Dict], class_name: str, bases=(
 _atomic_types = dict(bool=bool, str=str, int=int, float=float)
 
 
-def _join_default_for_str_repeat(default, sep):
-    """A List/Tuple schema default that gets exposed as a single sep-joined
-    string option (any repeat policy other than 'list'/'repeat') must be
-    pre-joined into that exact string shape. Left as the raw list/tuple
-    object, Click's STRING type falls back to str() when converting a
-    non-str default (since no CLI value was given to run through the real
-    parsing path), which yields a Python-repr string -- e.g.
-    "['ProposalId']" for an OmegaConf ListConfig. The bracket-stripping in
-    _validate_list/_validate_tuple then strips only the outer '[' ']'
-    characters, leaving the inner repr quote characters in place and
-    corrupting the value into "'ProposalId'" instead of leaving it alone.
+def _is_default_source(ctx, param) -> bool:
+    """True when *value* reaching a click.Option's callback came from the
+    option's own ``default=`` rather than something the user actually
+    typed (or an env var, config file, etc.) -- checked so a List/Tuple
+    option exposed as a single sep-joined string (any repeat policy other
+    than 'list'/'repeat') can hand the untouched ``schema.default`` object
+    straight back instead of round-tripping it through str-join-then-split.
+
+    That round trip is the wrong tool for this job even done carefully: a
+    List[str] default containing an element that itself contains the
+    configured separator (e.g. [\"a,b\"] under the default ',' policy) is
+    genuinely ambiguous to reconstruct from a joined string -- "a,b" splits
+    back into ["a", "b"], silently wrong, no error. Recognising "this is
+    the default, not real input" and skipping the string form entirely
+    sidesteps that ambiguity outright, and also means the default is
+    processed by the parameter it actually belongs to: Click's Parameter
+    dispatch calls a *bound* callback per option, but the surrounding
+    parameter-schema loop in clickify_parameters reassigns its own
+    loop-local variables (sep, policies, ...) every iteration, and a
+    callback that closes over one of those by name (rather than by a
+    default argument captured at lambda-creation time) reads whatever that
+    variable held on the loop's last pass, not this option's own -- a
+    classic late-binding bug. Every callback in this module now captures
+    what it needs as a default argument for exactly that reason.
     """
-    if default is None or isinstance(default, str):
+    return ctx.get_parameter_source(param.name) == click.core.ParameterSource.DEFAULT
+
+
+def _native_default(default, kind):
+    """*default* coerced to *kind* (``list`` or ``tuple``) -- the same
+    built-in type real (non-default) parsing produces -- so a caller can't
+    tell a handed-back default from a parsed value by its type. An
+    OmegaConf ListConfig default becomes a plain list/tuple; an
+    unset/None default passes through unchanged."""
+    if default is None or default in (UNSET, _UNSET_DEFAULT):
         return default
-    return sep.join(str(x) for x in default)
+    return kind(default)
 
 
 def _validate_list(text: str, element_type, schema, sep=",", brackets=True):
@@ -341,19 +363,17 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                             kwargs["default"] = None
                     elif policies.repeat == "[]":  # else assume [X,Y] or X,Y syntax
                         dtype = str
-                        if "default" in kwargs:
-                            kwargs["default"] = _join_default_for_str_repeat(kwargs["default"], ",")
                         validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type: (
-                            _validate_list(value, element_type=_type, schema=schema, brackets=False)
+                            _native_default(schema.default, list) if _is_default_source(ctx, param)
+                            else _validate_list(value, element_type=_type, schema=schema, brackets=False)
                         )
                         metavar = schema.metavar or f"{elem_type.__name__},{elem_type.__name__},..."
                     elif policies.repeat is not None:  # assume XrepY syntax
                         dtype = str
                         sep = policies.repeat
-                        if "default" in kwargs:
-                            kwargs["default"] = _join_default_for_str_repeat(kwargs["default"], sep)
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type: (
-                            _validate_list(value, element_type=_type, schema=schema, sep=sep, brackets=False)
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type, sep=sep: (
+                            _native_default(schema.default, list) if _is_default_source(ctx, param)
+                            else _validate_list(value, element_type=_type, schema=schema, sep=sep, brackets=False)
                         )
                         metavar = schema.metavar or f"{elem_type.__name__}{sep}{elem_type.__name__}{sep}..."
                     else:
@@ -368,21 +388,18 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                         raise SchemaError(f"tuple-type parameter '{name}' has unsupported repeat policy 'repeat'")
                     elif policies.repeat == "[]":  # else assume [X,Y] or X,Y syntax
                         dtype = str
-                        if "default" in kwargs:
-                            kwargs["default"] = _join_default_for_str_repeat(kwargs["default"], ",")
                         metavar = schema.metavar or ",".join((t.__name__ for t in elem_types))
                         validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types: (
-                            _validate_tuple(value, element_types=_type, schema=schema, brackets=False)
+                            _native_default(schema.default, tuple) if _is_default_source(ctx, param)
+                            else _validate_tuple(value, element_types=_type, schema=schema, brackets=False)
                         )
                     elif policies.repeat is not None:  # assume XrepY syntax
                         dtype = str
-                        if "default" in kwargs:
-                            kwargs["default"] = _join_default_for_str_repeat(kwargs["default"], policies.repeat)
-                        metavar = schema.metavar or policies.repeat.join((t.__name__ for t in elem_types))
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types: (
-                            _validate_tuple(
-                                value, element_types=_type, schema=schema, sep=policies.repeat, brackets=False
-                            )
+                        sep = policies.repeat
+                        metavar = schema.metavar or sep.join((t.__name__ for t in elem_types))
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types, sep=sep: (
+                            _native_default(schema.default, tuple) if _is_default_source(ctx, param)
+                            else _validate_tuple(value, element_types=_type, schema=schema, sep=sep, brackets=False)
                         )
                     else:
                         raise SchemaError(f"tuple-type parameter '{name}' does not have a repeat policy set")

--- a/src/scabha/schema_utils.py
+++ b/src/scabha/schema_utils.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E731 - ignore assignment of lambda expressions. TODO(JSKenyon): Fix this
+import functools
 import re
 from collections.abc import MutableMapping, MutableSequence, MutableSet
 from dataclasses import asdict, dataclass, field, make_dataclass
@@ -183,11 +184,32 @@ def _native_default(default, element_types):
         return None
     if isinstance(element_types, tuple):
         if len(default) != len(element_types):
-            raise SchemaError(
-                f"default {list(default)!r} does not match the declared tuple arity {len(element_types)}"
-            )
+            raise SchemaError(f"default {list(default)!r} does not match the declared tuple arity {len(element_types)}")
         return tuple(t(x) for t, x in zip(element_types, default))
     return [element_types(x) for x in default]
+
+
+def _list_validator(ctx, param, value, *, element_type, schema, dflt, sep=None):
+    """click.Option ``callback`` for a List[...] exposed as a single
+    sep-joined string option -- bound per-parameter via
+    ``functools.partial`` (see ``clickify_parameters``) rather than an
+    inline lambda, since a lambda's own parameter list is what kept
+    tripping ruff's line-length/formatting over a plain function call."""
+    if _is_default_source(ctx, param):
+        return _native_default(dflt, element_type)
+    if sep is None:
+        return _validate_list(value, element_type=element_type, schema=schema, brackets=False)
+    return _validate_list(value, element_type=element_type, schema=schema, sep=sep, brackets=False)
+
+
+def _tuple_validator(ctx, param, value, *, element_types, schema, dflt, sep=None):
+    """click.Option ``callback`` for a Tuple[...] exposed as a single
+    sep-joined string option -- see ``_list_validator``."""
+    if _is_default_source(ctx, param):
+        return _native_default(dflt, element_types)
+    if sep is None:
+        return _validate_tuple(value, element_types=element_types, schema=schema, brackets=False)
+    return _validate_tuple(value, element_types=element_types, schema=schema, sep=sep, brackets=False)
 
 
 def _validate_list(text: str, element_type, schema, sep=",", brackets=True):
@@ -387,19 +409,15 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                             kwargs["default"] = None
                     elif policies.repeat == "[]":  # else assume [X,Y] or X,Y syntax
                         dtype = str
-                        dflt = kwargs.get("default")
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type, dflt=dflt: (
-                            _native_default(dflt, _type) if _is_default_source(ctx, param)
-                            else _validate_list(value, element_type=_type, schema=schema, brackets=False)
+                        validator = functools.partial(
+                            _list_validator, element_type=elem_type, schema=schema, dflt=kwargs.get("default")
                         )
                         metavar = schema.metavar or f"{elem_type.__name__},{elem_type.__name__},..."
                     elif policies.repeat is not None:  # assume XrepY syntax
                         dtype = str
                         sep = policies.repeat
-                        dflt = kwargs.get("default")
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type, sep=sep, dflt=dflt: (
-                            _native_default(dflt, _type) if _is_default_source(ctx, param)
-                            else _validate_list(value, element_type=_type, schema=schema, sep=sep, brackets=False)
+                        validator = functools.partial(
+                            _list_validator, element_type=elem_type, schema=schema, dflt=kwargs.get("default"), sep=sep
                         )
                         metavar = schema.metavar or f"{elem_type.__name__}{sep}{elem_type.__name__}{sep}..."
                     else:
@@ -415,19 +433,19 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                     elif policies.repeat == "[]":  # else assume [X,Y] or X,Y syntax
                         dtype = str
                         metavar = schema.metavar or ",".join((t.__name__ for t in elem_types))
-                        dflt = kwargs.get("default")
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types, dflt=dflt: (
-                            _native_default(dflt, _type) if _is_default_source(ctx, param)
-                            else _validate_tuple(value, element_types=_type, schema=schema, brackets=False)
+                        validator = functools.partial(
+                            _tuple_validator, element_types=elem_types, schema=schema, dflt=kwargs.get("default")
                         )
                     elif policies.repeat is not None:  # assume XrepY syntax
                         dtype = str
                         sep = policies.repeat
                         metavar = schema.metavar or sep.join((t.__name__ for t in elem_types))
-                        dflt = kwargs.get("default")
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types, sep=sep, dflt=dflt: (
-                            _native_default(dflt, _type) if _is_default_source(ctx, param)
-                            else _validate_tuple(value, element_types=_type, schema=schema, sep=sep, brackets=False)
+                        validator = functools.partial(
+                            _tuple_validator,
+                            element_types=elem_types,
+                            schema=schema,
+                            dflt=kwargs.get("default"),
+                            sep=sep,
                         )
                     else:
                         raise SchemaError(f"tuple-type parameter '{name}' does not have a repeat policy set")

--- a/src/scabha/schema_utils.py
+++ b/src/scabha/schema_utils.py
@@ -155,15 +155,39 @@ def _is_default_source(ctx, param) -> bool:
     return ctx.get_parameter_source(param.name) == click.core.ParameterSource.DEFAULT
 
 
-def _native_default(default, kind):
-    """*default* coerced to *kind* (``list`` or ``tuple``) -- the same
-    built-in type real (non-default) parsing produces -- so a caller can't
-    tell a handed-back default from a parsed value by its type. An
-    OmegaConf ListConfig default becomes a plain list/tuple; an
-    unset/None default passes through unchanged."""
-    if default is None or default in (UNSET, _UNSET_DEFAULT):
-        return default
-    return kind(default)
+def _native_default(default, element_types):
+    """The value a callback hands back when Click asks it to process the
+    option's own default (see ``_is_default_source``) -- coerced exactly
+    as real parsing would coerce it: each element cast to its declared
+    type, and (for a Tuple) its arity checked -- so a default is
+    indistinguishable downstream from an equivalent typed ``--option
+    ...`` value, and a malformed schema default (wrong element type,
+    wrong tuple length) is caught here rather than silently let through
+    with the wrong shape.
+
+    *default* must be the click.Option's own already-resolved default --
+    i.e. ``kwargs.get("default")`` at the call site, not ``schema.default``
+    directly. Those two differ exactly for an omitted ``Optional[...]``
+    parameter: the surrounding code above deliberately sets the click
+    default to ``None`` in that case (stimela#415) even though
+    ``schema.default`` itself is still the UNSET/_UNSET_DEFAULT scabha
+    sentinel -- passing ``schema.default`` here would leak that sentinel
+    into the command's callback instead of the ``None`` the rest of this
+    module promises for an unset optional. Passing the resolved default
+    means the ``None`` case is handled by the same ``if default is None``
+    guard below with no special-casing needed.
+
+    *element_types* is a single type (List) or a tuple of types (Tuple).
+    """
+    if default is None:
+        return None
+    if isinstance(element_types, tuple):
+        if len(default) != len(element_types):
+            raise SchemaError(
+                f"default {list(default)!r} does not match the declared tuple arity {len(element_types)}"
+            )
+        return tuple(t(x) for t, x in zip(element_types, default))
+    return [element_types(x) for x in default]
 
 
 def _validate_list(text: str, element_type, schema, sep=",", brackets=True):
@@ -363,16 +387,18 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                             kwargs["default"] = None
                     elif policies.repeat == "[]":  # else assume [X,Y] or X,Y syntax
                         dtype = str
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type: (
-                            _native_default(schema.default, list) if _is_default_source(ctx, param)
+                        dflt = kwargs.get("default")
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type, dflt=dflt: (
+                            _native_default(dflt, _type) if _is_default_source(ctx, param)
                             else _validate_list(value, element_type=_type, schema=schema, brackets=False)
                         )
                         metavar = schema.metavar or f"{elem_type.__name__},{elem_type.__name__},..."
                     elif policies.repeat is not None:  # assume XrepY syntax
                         dtype = str
                         sep = policies.repeat
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type, sep=sep: (
-                            _native_default(schema.default, list) if _is_default_source(ctx, param)
+                        dflt = kwargs.get("default")
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type, sep=sep, dflt=dflt: (
+                            _native_default(dflt, _type) if _is_default_source(ctx, param)
                             else _validate_list(value, element_type=_type, schema=schema, sep=sep, brackets=False)
                         )
                         metavar = schema.metavar or f"{elem_type.__name__}{sep}{elem_type.__name__}{sep}..."
@@ -389,16 +415,18 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                     elif policies.repeat == "[]":  # else assume [X,Y] or X,Y syntax
                         dtype = str
                         metavar = schema.metavar or ",".join((t.__name__ for t in elem_types))
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types: (
-                            _native_default(schema.default, tuple) if _is_default_source(ctx, param)
+                        dflt = kwargs.get("default")
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types, dflt=dflt: (
+                            _native_default(dflt, _type) if _is_default_source(ctx, param)
                             else _validate_tuple(value, element_types=_type, schema=schema, brackets=False)
                         )
                     elif policies.repeat is not None:  # assume XrepY syntax
                         dtype = str
                         sep = policies.repeat
                         metavar = schema.metavar or sep.join((t.__name__ for t in elem_types))
-                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types, sep=sep: (
-                            _native_default(schema.default, tuple) if _is_default_source(ctx, param)
+                        dflt = kwargs.get("default")
+                        validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types, sep=sep, dflt=dflt: (
+                            _native_default(dflt, _type) if _is_default_source(ctx, param)
                             else _validate_tuple(value, element_types=_type, schema=schema, sep=sep, brackets=False)
                         )
                     else:

--- a/src/scabha/schema_utils.py
+++ b/src/scabha/schema_utils.py
@@ -127,6 +127,23 @@ def nested_schema_to_dataclass(nested: Dict[str, Dict], class_name: str, bases=(
 _atomic_types = dict(bool=bool, str=str, int=int, float=float)
 
 
+def _join_default_for_str_repeat(default, sep):
+    """A List/Tuple schema default that gets exposed as a single sep-joined
+    string option (any repeat policy other than 'list'/'repeat') must be
+    pre-joined into that exact string shape. Left as the raw list/tuple
+    object, Click's STRING type falls back to str() when converting a
+    non-str default (since no CLI value was given to run through the real
+    parsing path), which yields a Python-repr string -- e.g.
+    "['ProposalId']" for an OmegaConf ListConfig. The bracket-stripping in
+    _validate_list/_validate_tuple then strips only the outer '[' ']'
+    characters, leaving the inner repr quote characters in place and
+    corrupting the value into "'ProposalId'" instead of leaving it alone.
+    """
+    if default is None or isinstance(default, str):
+        return default
+    return sep.join(str(x) for x in default)
+
+
 def _validate_list(text: str, element_type, schema, sep=",", brackets=True):
     if not text:
         if schema.default in (UNSET, _UNSET_DEFAULT):
@@ -324,6 +341,8 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                             kwargs["default"] = None
                     elif policies.repeat == "[]":  # else assume [X,Y] or X,Y syntax
                         dtype = str
+                        if "default" in kwargs:
+                            kwargs["default"] = _join_default_for_str_repeat(kwargs["default"], ",")
                         validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type: (
                             _validate_list(value, element_type=_type, schema=schema, brackets=False)
                         )
@@ -331,6 +350,8 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                     elif policies.repeat is not None:  # assume XrepY syntax
                         dtype = str
                         sep = policies.repeat
+                        if "default" in kwargs:
+                            kwargs["default"] = _join_default_for_str_repeat(kwargs["default"], sep)
                         validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_type: (
                             _validate_list(value, element_type=_type, schema=schema, sep=sep, brackets=False)
                         )
@@ -347,12 +368,16 @@ def clickify_parameters(schemas: Union[str, Dict[str, Any]], default_policies: D
                         raise SchemaError(f"tuple-type parameter '{name}' has unsupported repeat policy 'repeat'")
                     elif policies.repeat == "[]":  # else assume [X,Y] or X,Y syntax
                         dtype = str
+                        if "default" in kwargs:
+                            kwargs["default"] = _join_default_for_str_repeat(kwargs["default"], ",")
                         metavar = schema.metavar or ",".join((t.__name__ for t in elem_types))
                         validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types: (
                             _validate_tuple(value, element_types=_type, schema=schema, brackets=False)
                         )
                     elif policies.repeat is not None:  # assume XrepY syntax
                         dtype = str
+                        if "default" in kwargs:
+                            kwargs["default"] = _join_default_for_str_repeat(kwargs["default"], policies.repeat)
                         metavar = schema.metavar or policies.repeat.join((t.__name__ for t in elem_types))
                         validator = lambda ctx, param, value, etype=dtype, schema=schema, _type=elem_types: (
                             _validate_tuple(

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -246,25 +246,33 @@ list_default_config = OmegaConf.create(
             "tags": dict(dtype="List[str]", default=["ProposalId"], info="single-element default"),
             "many": dict(dtype="List[str]", default=["a", "b", "c"], info="multi-element default"),
             "bracketed": dict(
-                dtype="List[str]", default=["x", "y"], policies=dict(repeat="[]"),
+                dtype="List[str]",
+                default=["x", "y"],
+                policies=dict(repeat="[]"),
                 info="bracket-syntax repeat policy",
             ),
             "colon-sep": dict(
-                dtype="List[str]", default=["p", "q"], policies=dict(repeat=":"),
+                dtype="List[str]",
+                default=["p", "q"],
+                policies=dict(repeat=":"),
                 info="a different separator, defined right after the default (',') ones -- "
-                     "regression case for the loop-variable late-binding bug",
+                "regression case for the loop-variable late-binding bug",
             ),
             "has-separator-in-value": dict(
-                dtype="List[str]", default=["a,b", "c"],
+                dtype="List[str]",
+                default=["a,b", "c"],
                 info="an element containing the configured separator itself -- must not be "
-                     "split back apart when the default is what's rendered, not real input",
+                "split back apart when the default is what's rendered, not real input",
             ),
             "tup-bracketed": dict(
-                dtype="Tuple[int, str]", default=[1, "x"], policies=dict(repeat="[]"),
+                dtype="Tuple[int, str]",
+                default=[1, "x"],
+                policies=dict(repeat="[]"),
                 info="tuple, bracket-syntax repeat policy",
             ),
             "tup-sep": dict(
-                dtype="Tuple[int, str]", default=[2, "y"],
+                dtype="Tuple[int, str]",
+                default=[2, "y"],
                 info="tuple, default ',' separator repeat policy",
             ),
         },
@@ -366,7 +374,8 @@ optional_no_default_config = OmegaConf.create(
         "inputs": {
             "maybe-tags": dict(dtype="Optional[List[str]]", info="no default given, default ',' policy"),
             "maybe-bracketed": dict(
-                dtype="Optional[List[str]]", policies=dict(repeat="[]"),
+                dtype="Optional[List[str]]",
+                policies=dict(repeat="[]"),
                 info="no default given, bracket-syntax policy",
             ),
             "maybe-pair": dict(dtype="Optional[Tuple[int, str]]", info="no default given"),

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -5,6 +5,7 @@ import click
 from click.testing import CliRunner
 from omegaconf import OmegaConf
 
+from scabha.exceptions import SchemaError
 from scabha.lazy_group import LazyGroup
 from scabha.schema_utils import clickify_parameters
 
@@ -354,6 +355,118 @@ def test_tuple_default_still_overridable_from_cli():
     result = runner.invoke(list_default_app, ["--tup-sep", "9,z"])
     assert result.exit_code == 0, result.output
     assert "tup_sep=(9, 'z')" in result.output
+
+
+# -- Omitted Optional[List/Tuple] must still reach the callback as plain
+# None (stimela#415's guarantee for Optional[str] etc.), not the scabha
+# UNSET/_UNSET_DEFAULT sentinel the default-shortcut was reading directly --
+
+optional_no_default_config = OmegaConf.create(
+    {
+        "inputs": {
+            "maybe-tags": dict(dtype="Optional[List[str]]", info="no default given, default ',' policy"),
+            "maybe-bracketed": dict(
+                dtype="Optional[List[str]]", policies=dict(repeat="[]"),
+                info="no default given, bracket-syntax policy",
+            ),
+            "maybe-pair": dict(dtype="Optional[Tuple[int, str]]", info="no default given"),
+        },
+        "outputs": {},
+    }
+)
+
+
+@click.command("optional-no-default-app")
+@clickify_parameters(optional_no_default_config)
+def optional_no_default_app(**kwargs):
+    for k, v in sorted(kwargs.items()):
+        click.echo(f"{k}={v!r}")
+
+
+def test_optional_list_no_default_reaches_callback_as_none():
+    runner = CliRunner()
+    result = runner.invoke(optional_no_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "maybe_tags=None" in result.output
+
+
+def test_optional_bracketed_list_no_default_reaches_callback_as_none():
+    runner = CliRunner()
+    result = runner.invoke(optional_no_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "maybe_bracketed=None" in result.output
+
+
+def test_optional_tuple_no_default_reaches_callback_as_none():
+    runner = CliRunner()
+    result = runner.invoke(optional_no_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "maybe_pair=None" in result.output
+
+
+# -- The default-shortcut must coerce elements/enforce tuple arity exactly
+# like real parsing does, not hand back whatever raw shape the schema
+# default happened to be authored in --
+
+typed_default_config = OmegaConf.create(
+    {
+        "inputs": {
+            "nums": dict(dtype="List[int]", default=["1", "2"], info="string elements in an int-list default"),
+            "pair": dict(dtype="Tuple[int, str]", default=[1, "y"], info="correct-arity tuple default"),
+        },
+        "outputs": {},
+    }
+)
+
+
+@click.command("typed-default-app")
+@clickify_parameters(typed_default_config)
+def typed_default_app(**kwargs):
+    for k, v in sorted(kwargs.items()):
+        click.echo(f"{k}={v!r} types={[type(x).__name__ for x in v]}")
+
+
+def test_list_default_elements_coerced_to_declared_type():
+    runner = CliRunner()
+    result = runner.invoke(typed_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "nums=[1, 2] types=['int', 'int']" in result.output
+
+
+def test_list_default_coercion_matches_real_cli_parsing():
+    runner = CliRunner()
+    result = runner.invoke(typed_default_app, ["--nums", "3,4"])
+    assert result.exit_code == 0, result.output
+    assert "nums=[3, 4] types=['int', 'int']" in result.output
+
+
+def test_tuple_default_elements_coerced_to_declared_types():
+    runner = CliRunner()
+    result = runner.invoke(typed_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "pair=(1, 'y') types=['int', 'str']" in result.output
+
+
+def test_tuple_default_wrong_arity_raises_schema_error():
+    bad_config = OmegaConf.create(
+        {
+            "inputs": {
+                "pair": dict(dtype="Tuple[int, str]", default=[1], info="wrong-arity default"),
+            },
+            "outputs": {},
+        }
+    )
+
+    @click.command("bad-arity-app")
+    @clickify_parameters(bad_config)
+    def bad_arity_app(**kwargs):
+        pass
+
+    runner = CliRunner()
+    result = runner.invoke(bad_arity_app, [])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, SchemaError)
+    assert "arity" in str(result.exception)
 
 
 # -- Existing lazy group tests --

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -248,6 +248,24 @@ list_default_config = OmegaConf.create(
                 dtype="List[str]", default=["x", "y"], policies=dict(repeat="[]"),
                 info="bracket-syntax repeat policy",
             ),
+            "colon-sep": dict(
+                dtype="List[str]", default=["p", "q"], policies=dict(repeat=":"),
+                info="a different separator, defined right after the default (',') ones -- "
+                     "regression case for the loop-variable late-binding bug",
+            ),
+            "has-separator-in-value": dict(
+                dtype="List[str]", default=["a,b", "c"],
+                info="an element containing the configured separator itself -- must not be "
+                     "split back apart when the default is what's rendered, not real input",
+            ),
+            "tup-bracketed": dict(
+                dtype="Tuple[int, str]", default=[1, "x"], policies=dict(repeat="[]"),
+                info="tuple, bracket-syntax repeat policy",
+            ),
+            "tup-sep": dict(
+                dtype="Tuple[int, str]", default=[2, "y"],
+                info="tuple, default ',' separator repeat policy",
+            ),
         },
         "outputs": {},
     }
@@ -287,6 +305,55 @@ def test_list_default_still_overridable_from_cli():
     result = runner.invoke(list_default_app, ["--tags", "Foo,Bar"])
     assert result.exit_code == 0, result.output
     assert "tags=['Foo', 'Bar']" in result.output
+
+
+def test_list_default_element_containing_the_separator_is_not_split():
+    # The default is handed back untouched rather than round-tripped
+    # through str-join-then-split, so an element that happens to contain
+    # the configured separator survives intact -- "a,b" stays one element,
+    # not two.
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "has_separator_in_value=['a,b', 'c']" in result.output
+
+
+def test_two_list_options_with_different_separators_each_keep_their_own_default():
+    # Regression for the loop-variable late-binding bug: 'tags'/'many' use
+    # the default ',' policy, 'colon-sep' is defined right after them with
+    # ':' -- each option's callback must use its own separator, not
+    # whichever one the parameter-schema loop had last set when the
+    # callback closures were created.
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "colon_sep=['p', 'q']" in result.output
+    # And each is still independently overridable with its own separator.
+    result = runner.invoke(list_default_app, ["--colon-sep", "m:n", "--tags", "Foo,Bar"])
+    assert result.exit_code == 0, result.output
+    assert "colon_sep=['m', 'n']" in result.output
+    assert "tags=['Foo', 'Bar']" in result.output
+
+
+def test_tuple_default_bracket_repeat_policy_not_corrupted():
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "tup_bracketed=(1, 'x')" in result.output
+
+
+def test_tuple_default_separator_repeat_policy_not_corrupted():
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "tup_sep=(2, 'y')" in result.output
+
+
+def test_tuple_default_still_overridable_from_cli():
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, ["--tup-sep", "9,z"])
+    assert result.exit_code == 0, result.output
+    assert "tup_sep=(9, 'z')" in result.output
 
 
 # -- Existing lazy group tests --

--- a/tests/test_clickify.py
+++ b/tests/test_clickify.py
@@ -234,6 +234,61 @@ def test_optional_str_override_default():
     assert "with_default='override.fits'" in result.output
 
 
+# -- Tests for List[str] defaults surfacing uncorrupted with no CLI override
+# (surfaced by ratt-ru/breifast#278's filter-by-metadata option: a schema
+# default of ['ProposalId'] was reaching the command's callback as the
+# repr-quoted string "'ProposalId'" instead of the plain "ProposalId") --
+
+list_default_config = OmegaConf.create(
+    {
+        "inputs": {
+            "tags": dict(dtype="List[str]", default=["ProposalId"], info="single-element default"),
+            "many": dict(dtype="List[str]", default=["a", "b", "c"], info="multi-element default"),
+            "bracketed": dict(
+                dtype="List[str]", default=["x", "y"], policies=dict(repeat="[]"),
+                info="bracket-syntax repeat policy",
+            ),
+        },
+        "outputs": {},
+    }
+)
+
+
+@click.command("list-default-app")
+@clickify_parameters(list_default_config)
+def list_default_app(**kwargs):
+    for k, v in sorted(kwargs.items()):
+        click.echo(f"{k}={v!r}")
+
+
+def test_list_default_single_element_not_corrupted():
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "tags=['ProposalId']" in result.output
+
+
+def test_list_default_multi_element_not_corrupted():
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "many=['a', 'b', 'c']" in result.output
+
+
+def test_list_default_bracket_repeat_policy_not_corrupted():
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, [])
+    assert result.exit_code == 0, result.output
+    assert "bracketed=['x', 'y']" in result.output
+
+
+def test_list_default_still_overridable_from_cli():
+    runner = CliRunner()
+    result = runner.invoke(list_default_app, ["--tags", "Foo,Bar"])
+    assert result.exit_code == 0, result.output
+    assert "tags=['Foo', 'Bar']" in result.output
+
+
 # -- Existing lazy group tests --
 
 


### PR DESCRIPTION
Killick here. Ran down a report that a breifast cab's `filter-by-metadata` filter pills never appeared unless the option was typed out explicitly on the command line, even though its schema carries a non-empty default. Turned out to be a bug in here, not in breifast.

## What's wrong

Any `List[str]`/`Tuple[...]` schema input surfaced as a single separator-joined string option (any `repeat` policy other than `list`/`repeat` — the implicit `,` default, or the `[]` bracket syntax) gets its non-empty default silently corrupted when the option isn't passed on the CLI.

Root cause: `clickify_parameters` sets `kwargs["default"] = schema.default` (the raw OmegaConf `ListConfig`, e.g. `['ProposalId']`) before the repeat-policy branch further down reassigns `dtype` to `str`. Click's `STRING` type then falls back to `str()` to convert that non-str default when nothing was typed on the CLI, producing a Python-repr-shaped string (`"['ProposalId']"`). The sep-joined validator's bracket-stripping only strips the outer `[`/`]` characters, leaving the inner repr quote marks in place — so the default ends up as `"'ProposalId'"` instead of `"ProposalId"`, and silently fails to match anything downstream.

## Fix (revised during review — see below)

The first pass here pre-joined a non-string default into the exact sep-joined string shape a user would type, then let the same parsing path reconstruct it. Review caught three real problems with that: a per-parameter separator/policy read from a mutable loop variable by name inside each callback closure (late-binding — a later parameter's separator/policy would silently apply to an earlier one's default), and a join that's lossy for any list element that itself contains the configured separator.

Redesigned around recognising the situation directly instead: each callback now checks `ctx.get_parameter_source(param.name) == click.core.ParameterSource.DEFAULT`, and when true, calls `_native_default(...)` to hand back the option's already-resolved default (`kwargs.get("default")`, not `schema.default` — those differ for an omitted `Optional[...]` parameter, where the click default is deliberately `None` per stimela#415, but `schema.default` is still the scabha `UNSET`/`_UNSET_DEFAULT` sentinel) with its elements coerced to their declared type and, for a Tuple, its arity checked — matching exactly what real parsing of an equivalent `--option ...` value would produce, and raising `SchemaError` on a malformed schema default (wrong element type, wrong tuple length) instead of silently returning the wrong shape. No string round-trip happens for a default at all, which also sidesteps the separator-ambiguity problem outright. Every callback now captures what it needs (`sep`, `schema`, element types, the resolved default) as bound lambda default arguments rather than reading a loop variable by name, which fixes the late-binding bug as a side effect.

## Verification

16 new tests in `tests/test_clickify.py` (30 total in the file), covering:
- single- and multi-element list defaults under both the default comma-separator policy and the `[]` bracket-syntax policy, plus CLI override
- a list element containing the configured separator surviving intact (not re-split)
- two list options with different separators defined back to back, each keeping its own default and its own real-input parsing
- `Tuple[...]` coverage for both the `[]` and separator-joined repeat policies (default, override, and asserted as an actual `tuple`, not a list)
- an omitted `Optional[List[...]]`/`Optional[List[...]]` with `[]` policy/`Optional[Tuple[...]]` each reaching the callback as `None`, not the `UNSET` sentinel
- `List[int]`/`Tuple[int, str]` default elements coerced to their declared type (confirmed to agree with real CLI-input parsing)
- a wrong-arity `Tuple[int, str]` default raising `SchemaError`

Full suite: 131 passed, no regressions.

Also confirmed against the actual breifast case: `filter-by-metadata`'s default `[ProposalId]`, plus `trove-tags`'s `[real]` and `dp-collapsed-sections`'s `["Detection cutouts"]` (same bug, just usually masked because they're passed explicitly), all now resolve to a proper `list` with a plain, unquoted string element — not the repr-quoted one.
