### PR TITLE
Pin the ruff rule set instead of extending the defaults

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -3,7 +3,19 @@ line-length = 120
 target-version = "py312"
 
 [lint]
-extend-select = [
+# Enumerated rather than extended. Ruff's *default* rule set is not stable
+# across releases -- 0.16 grew it from 59 rules to 413 and dropped 18 others
+# (E731 and E741 among them) -- so `extend-select` made the effective
+# configuration depend on which ruff binary happened to run. Listing the rules
+# explicitly means every ruff version lints this repo identically.
+#
+# E4, E7, E9 and F reproduce ruff's pre-0.16 defaults; E501 and I were the
+# project's own additions. See https://astral.sh/blog/ruff-v0.16.0
+select = [
+    "E4",    # pycodestyle: imports
+    "E7",    # pycodestyle: statements
+    "E9",    # pycodestyle: runtime/syntax errors
+    "F",     # pyflakes
     "E501",  # Line length
-    "I"      # isort - sort imports
+    "I",     # isort - sort imports
 ]


### PR DESCRIPTION
## The problem

Ruff's default rule set changes between releases. In 0.16 it went from 59 rules to 413, and 18 rules were dropped — including `E731` and `E741`.

Because `ruff.toml` used `extend-select`, that meant the rules actually applied to this repo depended on whichever ruff binary happened to run. We currently have three: pre-commit pins 0.12.9, the dev group resolves 0.15.20, and `uvx ruff` fetches whatever is newest.

This isn't theoretical. Running `uvx ruff check --fix` on a clean checkout today:

- deletes the `# ruff: noqa: E731` / `E741` headers at the top of `schema_utils.py`, `validate.py` and `evaluator.py`. Under 0.16 those rules aren't enabled, so `RUF100` (newly enabled by default) considers the suppressions dead. Two of them carry `TODO(JSKenyon)` notes.
- applies 311 further fixes, including pyupgrade rewrites to PEP 604 syntax that our `target-version` doesn't match.

Run any older ruff afterwards and you get 11 unguarded violations that were previously suppressed on purpose.

## The change

List the rules explicitly rather than extending whatever the defaults happen to be. `E4`, `E7`, `E9` and `F` are ruff's pre-0.16 defaults; `E501` and `I` were already ours.

`ruff.toml` is the only file touched. No source changes.

## Checks

Verified under 0.12.9, 0.15.20 and 0.16.4:

| | 0.12.9 | 0.15.20 | 0.16.4 |
|---|---|---|---|
| `ruff check` | pass | pass | pass |
| `ruff format --check` | clean | clean | clean |
| `ruff check --fix` | no-op | no-op | no-op |
| E731/E741 with the noqa headers stripped | 7 + 4 | 7 + 4 | 7 + 4 |

That last row matters: it confirms the rules are still genuinely enforced rather than quietly absent, so the existing suppressions and their TODOs stay meaningful.

Tests pass unchanged (115).

## Deliberately not in scope

`target-version = "py312"` still disagrees with `requires-python = ">=3.9"`. It's inert here since no pyupgrade rules are selected, but it's worth fixing separately — as things stand, anyone who later adds `"UP"` to `select` would reintroduce exactly the 3.9-breaking rewrites described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)