### PR TITLE
Fix empty published wheel (sdist target strips src/ before wheel build)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scabha"
-version = "2.2.0rc3"
+version = "2.2.0rc4"
 description = "Argument parser and validation tool for (not just) radio interferometry"
 authors = [
     { name = "Oleg Smirnov and RATT", email = "osmirnov@gmail.com" },
@@ -35,11 +35,6 @@ dev = [
     "pre-commit>=4.3.0",
     "ruff>=0.12.9",
     "jupyter"
-]
-
-[tool.hatch.build.targets.sdist]
-packages = [
-    "src/scabha"
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
Killick here. Prof reported the just-published `2.2.0rc3` PyPI package contains no Python files. Reproduced locally.

## Root cause

`python -m build` builds the sdist first, then builds the wheel **from that sdist** (the standard two-stage path — also exactly what `.github/workflows/publish-package.yml` does: `python -m build && twine upload dist/*`).

`[tool.hatch.build.targets.sdist]`'s `packages = ["src/scabha"]` re-roots the source tree, stripping the `src/` prefix — the built sdist contains `scabha/*.py` at its top level, not `src/scabha/*.py`. `[tool.hatch.build.targets.wheel]`'s `packages = ["src/scabha"]` then looks for that `src/scabha` path **inside the extracted sdist** to build the wheel — but it no longer exists there, since the sdist step already flattened it. hatchling doesn't error on the empty match; it silently produces a wheel with zero source files, only `.dist-info` metadata.

Building the wheel directly from the working tree (skipping the sdist stage — e.g. `pip install -e .`) never hits this, which is presumably how it went unnoticed for so long.

**Pre-existing bug, not introduced by #42** — traced back to the original "Move to src layout" work (reverted once, reapplied); this `pyproject.toml` shape has been in master since before this release.

## Fix

Drop the sdist target's custom `packages` override entirely. Without it, hatchling's default sdist behaviour preserves the full source tree (`src/` prefix intact), so the wheel target's existing `packages = ["src/scabha"]` finds what it expects whether building directly from the working tree or from an extracted sdist — the two build paths agree again.

## Version bump

Bumped to `2.2.0rc4`: PyPI rejects re-uploading a filename that already exists for an immutable release, so a fixed wheel can't be published under the `rc3` tag/version — `2.2.0rc3`'s release needs to be superseded by a new one regardless of this fix.

## Verification

Not just file-listing inspection — built via `python -m build` (the same two-stage sdist-then-wheel path the release workflow uses), confirmed the wheel contains all 18 `scabha/*.py` files, then `pip install`ed that exact wheel into a fresh venv and imported `scabha.schema_utils` successfully — confirming the #42 fix (`_is_default_source`) is actually present in the installed package this time. Full test suite: 131 passed. `ruff check`/`ruff format --check` both clean.
